### PR TITLE
move toEqualDocument to jest config

### DIFF
--- a/__tests__/helpers.js
+++ b/__tests__/helpers.js
@@ -1,11 +1,4 @@
-import {
-  createEditor,
-  doc,
-  p,
-  strong,
-  atomInline,
-  toEqualDocument
-} from '../test-helpers';
+import { createEditor, doc, p, strong, atomInline } from '../test-helpers';
 import { Fragment } from 'prosemirror-model';
 import { canInsert, removeNodeAtPos } from '../src/helpers';
 
@@ -13,14 +6,18 @@ describe('helpers', () => {
   describe('canInsert', () => {
     it('should return true if insertion of a given node is allowed at the current cursor position', () => {
       const { state } = createEditor(doc(p('one<cursor>')));
-      const { selection: { $from } } = state;
+      const {
+        selection: { $from }
+      } = state;
       const node = state.schema.nodes.atomInline.createChecked();
       expect(canInsert($from, node)).toBe(true);
     });
 
     it('should return true if insertion of a given Fragment is allowed at the current cursor position', () => {
       const { state } = createEditor(doc(p('one<cursor>')));
-      const { selection: { $from } } = state;
+      const {
+        selection: { $from }
+      } = state;
       const node = state.schema.nodes.atomInline.createChecked();
       expect(canInsert($from, Fragment.from(node))).toBe(true);
     });
@@ -29,7 +26,9 @@ describe('helpers', () => {
       const { state } = createEditor(
         doc(p(strong('zero'), 'o<cursor>ne'), p('three'))
       );
-      const { selection: { $from } } = state;
+      const {
+        selection: { $from }
+      } = state;
       const node = state.schema.nodes.paragraph.createChecked(
         {},
         state.schema.text('two')
@@ -41,7 +40,9 @@ describe('helpers', () => {
       const { state } = createEditor(
         doc(p(strong('zero'), 'o<cursor>ne'), p('three'))
       );
-      const { selection: { $from } } = state;
+      const {
+        selection: { $from }
+      } = state;
       const node = state.schema.nodes.paragraph.createChecked(
         {},
         state.schema.text('two')
@@ -52,17 +53,21 @@ describe('helpers', () => {
 
   describe('removeNodeAtPos', () => {
     it('should remove a block top level node at the given position', () => {
-      const { state: { tr } } = createEditor(doc(p('x'), p('one')));
+      const {
+        state: { tr }
+      } = createEditor(doc(p('x'), p('one')));
       const newTr = removeNodeAtPos(4)(tr);
       expect(newTr).not.toBe(tr);
-      toEqualDocument(newTr.doc, doc(p('x')));
+      expect(newTr.doc).toEqualDocument(doc(p('x')));
     });
 
     it('should remove a nested inline node at the given position', () => {
-      const { state: { tr } } = createEditor(doc(p('one', atomInline())));
+      const {
+        state: { tr }
+      } = createEditor(doc(p('one', atomInline())));
       const newTr = removeNodeAtPos(5)(tr);
       expect(newTr).not.toBe(tr);
-      toEqualDocument(newTr.doc, doc(p('one')));
+      expect(newTr.doc).toEqualDocument(doc(p('one')));
     });
   });
 });

--- a/__tests__/table.js
+++ b/__tests__/table.js
@@ -7,8 +7,7 @@ import {
   td,
   th,
   tdCursor,
-  tdEmpty,
-  toEqualDocument
+  tdEmpty
 } from '../test-helpers';
 import {
   findTable,
@@ -35,12 +34,16 @@ import {
 describe('table', () => {
   describe('findTable', () => {
     it('should find table node if cursor is inside of a table cell', () => {
-      const { state: { selection } } = createEditor(doc(table(row(tdCursor))));
+      const {
+        state: { selection }
+      } = createEditor(doc(table(row(tdCursor))));
       const { node } = findTable(selection);
       expect(node.type.name).toEqual('table');
     });
     it('should return `undefined` if there is no table parent node', () => {
-      const { state: { selection } } = createEditor(doc(p('<cursor>')));
+      const {
+        state: { selection }
+      } = createEditor(doc(p('<cursor>')));
       const result = findTable(selection);
       expect(result).toBeUndefined();
     });
@@ -48,26 +51,32 @@ describe('table', () => {
 
   describe('isCellSelection', () => {
     it('should return `true` if current selection is a CellSelection', () => {
-      const { state: { selection } } = createEditor(
-        doc(table(row(td(p('<anchor>')), td(p('<head>')))))
-      );
+      const {
+        state: { selection }
+      } = createEditor(doc(table(row(td(p('<anchor>')), td(p('<head>'))))));
       expect(isCellSelection(selection)).toBe(true);
     });
     it('should return `false` if current selection is not a CellSelection', () => {
-      const { state: { selection } } = createEditor(doc(p('<cursor>')));
+      const {
+        state: { selection }
+      } = createEditor(doc(p('<cursor>')));
       expect(isCellSelection(selection)).toBe(false);
     });
   });
 
   describe('isColumnSelected', () => {
     it('should return `true` if CellSelection spans the entire column', () => {
-      const { state: { selection } } = createEditor(
+      const {
+        state: { selection }
+      } = createEditor(
         doc(table(row(td(p('<anchor>'))), row(tdEmpty), row(td(p('<head>')))))
       );
       expect(isColumnSelected(0)(selection)).toBe(true);
     });
     it('should return `false` if CellSelection does not span the entire column', () => {
-      const { state: { selection } } = createEditor(
+      const {
+        state: { selection }
+      } = createEditor(
         doc(table(row(td(p('<anchor>'))), row(td(p('<head>'))), row(tdEmpty)))
       );
       expect(isColumnSelected(0)(selection)).toBe(false);
@@ -76,13 +85,17 @@ describe('table', () => {
 
   describe('isRowSelected', () => {
     it('should return `true` if CellSelection spans the entire row', () => {
-      const { state: { selection } } = createEditor(
+      const {
+        state: { selection }
+      } = createEditor(
         doc(table(row(td(p('<anchor>')), tdEmpty, td(p('<head>')))))
       );
       expect(isRowSelected(0)(selection)).toBe(true);
     });
     it('should return `false` if CellSelection does not span the entire row', () => {
-      const { state: { selection } } = createEditor(
+      const {
+        state: { selection }
+      } = createEditor(
         doc(table(row(td(p('<anchor>')), td(p('<head>')), tdEmpty)))
       );
       expect(isRowSelected(0)(selection)).toBe(false);
@@ -91,7 +104,9 @@ describe('table', () => {
 
   describe('isTableSelected', () => {
     it('should return `true` if CellSelection spans the entire table', () => {
-      const { state: { selection } } = createEditor(
+      const {
+        state: { selection }
+      } = createEditor(
         doc(
           table(
             row(td(p('<anchor>')), tdEmpty, tdEmpty),
@@ -102,7 +117,9 @@ describe('table', () => {
       expect(isTableSelected(selection)).toBe(true);
     });
     it('should return `false` if CellSelection does not span the entire table', () => {
-      const { state: { selection } } = createEditor(
+      const {
+        state: { selection }
+      } = createEditor(
         doc(
           table(
             row(td(p('<anchor>')), tdEmpty, tdEmpty),
@@ -116,11 +133,15 @@ describe('table', () => {
 
   describe('getCellsInColumn', () => {
     it('should return `undefined` when cursor is outside of a table node', () => {
-      const { state: { selection } } = createEditor(doc(p('<cursor>')));
+      const {
+        state: { selection }
+      } = createEditor(doc(p('<cursor>')));
       expect(getCellsInColumn(0)(selection)).toBeUndefined();
     });
     it('should return an array of cells in a column', () => {
-      const { state: { selection } } = createEditor(
+      const {
+        state: { selection }
+      } = createEditor(
         doc(
           table(
             row(td(p('1')), tdCursor, tdEmpty),
@@ -141,11 +162,15 @@ describe('table', () => {
 
   describe('getCellsInRow', () => {
     it('should return `undefined` when cursor is outside of a table node', () => {
-      const { state: { selection } } = createEditor(doc(p('<cursor>')));
+      const {
+        state: { selection }
+      } = createEditor(doc(p('<cursor>')));
       expect(getCellsInRow(0)(selection)).toBeUndefined();
     });
     it('should return an array of cells in a row', () => {
-      const { state: { selection } } = createEditor(
+      const {
+        state: { selection }
+      } = createEditor(
         doc(
           table(
             row(td(p('1')), td(p('2')), td(p('3'))),
@@ -167,11 +192,15 @@ describe('table', () => {
 
   describe('getCellsInTable', () => {
     it('should return `undefined` when cursor is outside of a table node', () => {
-      const { state: { selection } } = createEditor(doc(p('<cursor>')));
+      const {
+        state: { selection }
+      } = createEditor(doc(p('<cursor>')));
       expect(getCellsInTable(selection)).toBeUndefined();
     });
     it('should return an array of all cells', () => {
-      const { state: { selection } } = createEditor(
+      const {
+        state: { selection }
+      } = createEditor(
         doc(
           table(
             row(td(p('1<cursor>')), td(p('2')), td(p('3'))),
@@ -196,14 +225,16 @@ describe('table', () => {
 
   describe('selectColumn', () => {
     it("should return an original transaction if table doesn't have a column at `columnIndex`", () => {
-      const { state: { tr } } = createEditor(
-        doc(table(row(td(p('1<cursor>')), td(p('2')))))
-      );
+      const {
+        state: { tr }
+      } = createEditor(doc(table(row(td(p('1<cursor>')), td(p('2'))))));
       const newTr = selectColumn(2)(tr);
       expect(tr).toBe(newTr);
     });
     it('should return a new transaction that selects a column at `columnIndex`', () => {
-      const { state: { tr } } = createEditor(
+      const {
+        state: { tr }
+      } = createEditor(
         doc(
           table(
             row(td(p('1<cursor>')), td(p('2'))),
@@ -220,14 +251,16 @@ describe('table', () => {
 
   describe('selectRow', () => {
     it("should return an original transaction if table doesn't have a row at `rowIndex`", () => {
-      const { state: { tr } } = createEditor(
-        doc(table(row(td(p('1<cursor>'))), row(td(p('2')))))
-      );
+      const {
+        state: { tr }
+      } = createEditor(doc(table(row(td(p('1<cursor>'))), row(td(p('2'))))));
       const newTr = selectRow(2)(tr);
       expect(tr).toBe(newTr);
     });
     it('should return a new transaction that selects a row at `rowIndex`', () => {
-      const { state: { tr } } = createEditor(
+      const {
+        state: { tr }
+      } = createEditor(
         doc(
           table(
             row(td(p('1<cursor>')), td(p('2'))),
@@ -244,7 +277,9 @@ describe('table', () => {
 
   describe('selectTable', () => {
     it('should return a new transaction that selects the entire table', () => {
-      const { state: { tr } } = createEditor(
+      const {
+        state: { tr }
+      } = createEditor(
         doc(
           table(
             row(td(p('1<cursor>')), td(p('2'))),
@@ -261,7 +296,9 @@ describe('table', () => {
 
   describe('emptySelectedCells', () => {
     it('should return a new transaction that selects the entire table', () => {
-      const { state: { schema, tr } } = createEditor(
+      const {
+        state: { schema, tr }
+      } = createEditor(
         doc(
           table(
             row(td(p('1<cursor>')), td(p('2'))),
@@ -271,8 +308,7 @@ describe('table', () => {
       );
       const newTr = emptySelectedCells(schema)(selectColumn(0)(tr));
       expect(newTr).not.toBe(tr);
-      toEqualDocument(
-        newTr.doc,
+      expect(newTr.doc).toEqualDocument(
         doc(table(row(td(p('')), td(p('2'))), row(td(p('')), td(p('4')))))
       );
     });
@@ -280,14 +316,16 @@ describe('table', () => {
 
   describe('addColumnAt', () => {
     it("should return an original transaction if table doesn't have a column at `columnIndex`", () => {
-      const { state: { tr } } = createEditor(
-        doc(table(row(td(p('1<cursor>')), td(p('2')))))
-      );
+      const {
+        state: { tr }
+      } = createEditor(doc(table(row(td(p('1<cursor>')), td(p('2'))))));
       const newTr = addColumnAt(3)(tr);
       expect(tr).toBe(newTr);
     });
     it('should return a new transaction that adds a new column at index 0', () => {
-      const { state: { schema, tr } } = createEditor(
+      const {
+        state: { schema, tr }
+      } = createEditor(
         doc(
           table(
             row(td(p('1<cursor>')), td(p('2'))),
@@ -297,8 +335,7 @@ describe('table', () => {
       );
       const newTr = addColumnAt(0)(tr);
       expect(newTr).not.toBe(tr);
-      toEqualDocument(
-        newTr.doc,
+      expect(newTr.doc).toEqualDocument(
         doc(
           table(
             row(tdEmpty, td(p('1')), td(p('2'))),
@@ -308,7 +345,9 @@ describe('table', () => {
       );
     });
     it('should return a new transaction that adds a new column in the middle', () => {
-      const { state: { schema, tr } } = createEditor(
+      const {
+        state: { schema, tr }
+      } = createEditor(
         doc(
           table(
             row(td(p('1<cursor>')), td(p('2'))),
@@ -318,8 +357,7 @@ describe('table', () => {
       );
       const newTr = addColumnAt(1)(tr);
       expect(newTr).not.toBe(tr);
-      toEqualDocument(
-        newTr.doc,
+      expect(newTr.doc).toEqualDocument(
         doc(
           table(
             row(td(p('1')), tdEmpty, td(p('2'))),
@@ -329,7 +367,9 @@ describe('table', () => {
       );
     });
     it('should return a new transaction that adds a new column at last index', () => {
-      const { state: { schema, tr } } = createEditor(
+      const {
+        state: { schema, tr }
+      } = createEditor(
         doc(
           table(
             row(td(p('1<cursor>')), td(p('2'))),
@@ -339,8 +379,7 @@ describe('table', () => {
       );
       const newTr = addColumnAt(2)(tr);
       expect(newTr).not.toBe(tr);
-      toEqualDocument(
-        newTr.doc,
+      expect(newTr.doc).toEqualDocument(
         doc(
           table(
             row(td(p('1')), td(p('2')), tdEmpty),
@@ -353,7 +392,9 @@ describe('table', () => {
 
   describe('addRowAt', () => {
     it("should return an original transaction if table doesn't have a row at `rowIndex`", () => {
-      const { state: { tr } } = createEditor(
+      const {
+        state: { tr }
+      } = createEditor(
         doc(
           table(
             row(td(p('1<cursor>')), td(p('2'))),
@@ -365,7 +406,9 @@ describe('table', () => {
       expect(tr).toBe(newTr);
     });
     it('should return a new transaction that adds a new row at index 0', () => {
-      const { state: { schema, tr } } = createEditor(
+      const {
+        state: { schema, tr }
+      } = createEditor(
         doc(
           table(
             row(td(p('1<cursor>')), td(p('2'))),
@@ -375,8 +418,7 @@ describe('table', () => {
       );
       const newTr = addRowAt(0)(tr);
       expect(newTr).not.toBe(tr);
-      toEqualDocument(
-        newTr.doc,
+      expect(newTr.doc).toEqualDocument(
         doc(
           table(
             row(tdEmpty, tdEmpty),
@@ -387,7 +429,9 @@ describe('table', () => {
       );
     });
     it('should return a new transaction that adds a new row in the middle', () => {
-      const { state: { schema, tr } } = createEditor(
+      const {
+        state: { schema, tr }
+      } = createEditor(
         doc(
           table(
             row(td(p('1<cursor>')), td(p('2'))),
@@ -397,8 +441,7 @@ describe('table', () => {
       );
       const newTr = addRowAt(1)(tr);
       expect(newTr).not.toBe(tr);
-      toEqualDocument(
-        newTr.doc,
+      expect(newTr.doc).toEqualDocument(
         doc(
           table(
             row(td(p('1')), td(p('2'))),
@@ -409,7 +452,9 @@ describe('table', () => {
       );
     });
     it('should return a new transaction that adds a new row at last index', () => {
-      const { state: { schema, tr } } = createEditor(
+      const {
+        state: { schema, tr }
+      } = createEditor(
         doc(
           table(
             row(td(p('1<cursor>')), td(p('2'))),
@@ -419,8 +464,7 @@ describe('table', () => {
       );
       const newTr = addRowAt(2)(tr);
       expect(newTr).not.toBe(tr);
-      toEqualDocument(
-        newTr.doc,
+      expect(newTr.doc).toEqualDocument(
         doc(
           table(
             row(td(p('1')), td(p('2'))),
@@ -434,14 +478,16 @@ describe('table', () => {
 
   describe('removeColumnAt', () => {
     it("should return an original transaction if table doesn't have a column at `columnIndex`", () => {
-      const { state: { tr } } = createEditor(
-        doc(table(row(td(p('1<cursor>')), td(p('2')))))
-      );
+      const {
+        state: { tr }
+      } = createEditor(doc(table(row(td(p('1<cursor>')), td(p('2'))))));
       const newTr = removeColumnAt(3)(tr);
       expect(tr).toBe(newTr);
     });
     it('should return a new transaction that removes a column at index 0', () => {
-      const { state: { schema, tr } } = createEditor(
+      const {
+        state: { schema, tr }
+      } = createEditor(
         doc(
           table(
             row(td(p('1<cursor>')), td(p('2'))),
@@ -451,10 +497,14 @@ describe('table', () => {
       );
       const newTr = removeColumnAt(0)(tr);
       expect(newTr).not.toBe(tr);
-      toEqualDocument(newTr.doc, doc(table(row(td(p('2'))), row(td(p('4'))))));
+      expect(newTr.doc).toEqualDocument(
+        doc(table(row(td(p('2'))), row(td(p('4')))))
+      );
     });
     it('should return a new transaction that removes a column in the middle', () => {
-      const { state: { schema, tr } } = createEditor(
+      const {
+        state: { schema, tr }
+      } = createEditor(
         doc(
           table(
             row(td(p('1<cursor>')), td(p('2')), td(p('3'))),
@@ -464,13 +514,14 @@ describe('table', () => {
       );
       const newTr = removeColumnAt(1)(tr);
       expect(newTr).not.toBe(tr);
-      toEqualDocument(
-        newTr.doc,
+      expect(newTr.doc).toEqualDocument(
         doc(table(row(td(p('1')), td(p('3'))), row(td(p('4')), td(p('6')))))
       );
     });
     it('should return a new transaction that removes a column at last index', () => {
-      const { state: { schema, tr } } = createEditor(
+      const {
+        state: { schema, tr }
+      } = createEditor(
         doc(
           table(
             row(td(p('1<cursor>')), td(p('2'))),
@@ -480,13 +531,17 @@ describe('table', () => {
       );
       const newTr = removeColumnAt(1)(tr);
       expect(newTr).not.toBe(tr);
-      toEqualDocument(newTr.doc, doc(table(row(td(p('1'))), row(td(p('3'))))));
+      expect(newTr.doc).toEqualDocument(
+        doc(table(row(td(p('1'))), row(td(p('3')))))
+      );
     });
   });
 
   describe('removeRowAt', () => {
     it("should return an original transaction if table doesn't have a row at `rowIndex`", () => {
-      const { state: { tr } } = createEditor(
+      const {
+        state: { tr }
+      } = createEditor(
         doc(
           table(
             row(td(p('1<cursor>')), td(p('2'))),
@@ -498,7 +553,9 @@ describe('table', () => {
       expect(tr).toBe(newTr);
     });
     it('should return a new transaction that removes a row at index 0', () => {
-      const { state: { schema, tr } } = createEditor(
+      const {
+        state: { schema, tr }
+      } = createEditor(
         doc(
           table(
             row(td(p('1<cursor>')), td(p('2'))),
@@ -508,10 +565,14 @@ describe('table', () => {
       );
       const newTr = removeRowAt(0)(tr);
       expect(newTr).not.toBe(tr);
-      toEqualDocument(newTr.doc, doc(table(row(td(p('3')), td(p('4'))))));
+      expect(newTr.doc).toEqualDocument(
+        doc(table(row(td(p('3')), td(p('4')))))
+      );
     });
     it('should return a new transaction that removes a row in the middle', () => {
-      const { state: { schema, tr } } = createEditor(
+      const {
+        state: { schema, tr }
+      } = createEditor(
         doc(
           table(
             row(td(p('1<cursor>')), td(p('2'))),
@@ -522,13 +583,14 @@ describe('table', () => {
       );
       const newTr = removeRowAt(1)(tr);
       expect(newTr).not.toBe(tr);
-      toEqualDocument(
-        newTr.doc,
+      expect(newTr.doc).toEqualDocument(
         doc(table(row(td(p('1')), td(p('2'))), row(td(p('5')), td(p('6')))))
       );
     });
     it('should return a new transaction that removes a row at last index', () => {
-      const { state: { schema, tr } } = createEditor(
+      const {
+        state: { schema, tr }
+      } = createEditor(
         doc(
           table(
             row(td(p('1<cursor>')), td(p('2'))),
@@ -538,20 +600,24 @@ describe('table', () => {
       );
       const newTr = removeRowAt(1)(tr);
       expect(newTr).not.toBe(tr);
-      toEqualDocument(newTr.doc, doc(table(row(td(p('1')), td(p('2'))))));
+      expect(newTr.doc).toEqualDocument(
+        doc(table(row(td(p('1')), td(p('2')))))
+      );
     });
   });
 
   describe('removeSelectedColumns', () => {
     it('should return an original transaction if selection is not a CellSelection', () => {
-      const { state: { tr } } = createEditor(
-        doc(table(row(td(p('1<cursor>')), td(p('2')))))
-      );
+      const {
+        state: { tr }
+      } = createEditor(doc(table(row(td(p('1<cursor>')), td(p('2'))))));
       const newTr = removeSelectedColumns(tr);
       expect(tr).toBe(newTr);
     });
     it('should return a new transaction that removes selected columns', () => {
-      const { state: { schema, tr } } = createEditor(
+      const {
+        state: { schema, tr }
+      } = createEditor(
         doc(
           table(
             row(td(p('1<anchor>')), tdEmpty, tdEmpty),
@@ -561,10 +627,12 @@ describe('table', () => {
       );
       const newTr = removeSelectedColumns(tr);
       expect(newTr).not.toBe(tr);
-      toEqualDocument(newTr.doc, doc(table(row(tdEmpty), row(tdEmpty))));
+      expect(newTr.doc).toEqualDocument(doc(table(row(tdEmpty), row(tdEmpty))));
     });
     it('should return a new transaction that removes entire table if all columns are selected', () => {
-      const { state: { schema, tr } } = createEditor(
+      const {
+        state: { schema, tr }
+      } = createEditor(
         doc(
           table(
             row(td(p('1<anchor>')), tdEmpty, tdEmpty),
@@ -574,20 +642,22 @@ describe('table', () => {
       );
       const newTr = removeSelectedColumns(tr);
       expect(newTr).not.toBe(tr);
-      toEqualDocument(newTr.doc, doc(p('')));
+      expect(newTr.doc).toEqualDocument(doc(p('')));
     });
   });
 
   describe('removeSelectedRows', () => {
     it('should return an original transaction if selection is not a CellSelection', () => {
-      const { state: { tr } } = createEditor(
-        doc(table(row(td(p('1<cursor>')), td(p('2')))))
-      );
+      const {
+        state: { tr }
+      } = createEditor(doc(table(row(td(p('1<cursor>')), td(p('2'))))));
       const newTr = removeSelectedRows(tr);
       expect(tr).toBe(newTr);
     });
     it('should return a new transaction that removes selected columns', () => {
-      const { state: { schema, tr } } = createEditor(
+      const {
+        state: { schema, tr }
+      } = createEditor(
         doc(
           table(
             row(td(p('1<anchor>')), tdEmpty, tdEmpty),
@@ -598,10 +668,14 @@ describe('table', () => {
       );
       const newTr = removeSelectedRows(tr);
       expect(newTr).not.toBe(tr);
-      toEqualDocument(newTr.doc, doc(table(row(tdEmpty, tdEmpty, tdEmpty))));
+      expect(newTr.doc).toEqualDocument(
+        doc(table(row(tdEmpty, tdEmpty, tdEmpty)))
+      );
     });
     it('should return a new transaction that removes entire table if all columns are selected', () => {
-      const { state: { schema, tr } } = createEditor(
+      const {
+        state: { schema, tr }
+      } = createEditor(
         doc(
           table(
             row(td(p('1<anchor>')), tdEmpty, tdEmpty),
@@ -611,25 +685,27 @@ describe('table', () => {
       );
       const newTr = removeSelectedRows(tr);
       expect(newTr).not.toBe(tr);
-      toEqualDocument(newTr.doc, doc(p('')));
+      expect(newTr.doc).toEqualDocument(doc(p('')));
     });
   });
 
   describe('removeTable', () => {
     it('should return an original transaction that removes a table if cursor is not inside of it', () => {
-      const { state: { tr } } = createEditor(
-        doc(p('<cursor>'), table(row(td(p('1')), td(p('2')))))
-      );
+      const {
+        state: { tr }
+      } = createEditor(doc(p('<cursor>'), table(row(td(p('1')), td(p('2'))))));
       const newTr = removeTable(tr);
       expect(tr).toBe(newTr);
     });
     it('should return a new transaction that removes a table if cursor is inside', () => {
-      const { state: { schema, tr } } = createEditor(
+      const {
+        state: { schema, tr }
+      } = createEditor(
         doc(table(row(td(p('1<cursor>')), tdEmpty), row(tdEmpty, tdEmpty)))
       );
       const newTr = removeTable(tr);
       expect(newTr).not.toBe(tr);
-      toEqualDocument(newTr.doc, doc(p('')));
+      expect(newTr.doc).toEqualDocument(doc(p('')));
     });
   });
 });

--- a/__tests__/transforms.js
+++ b/__tests__/transforms.js
@@ -1,6 +1,5 @@
 import {
   createEditor,
-  toEqualDocument,
   doc,
   p,
   strong,
@@ -31,67 +30,73 @@ import {
 describe('transforms', () => {
   describe('removeParentNodeOfType', () => {
     it('should return an original transaction if there is no parent node of a given NodeType', () => {
-      const { state: { schema, tr } } = createEditor(doc(p('<cursor>')));
+      const {
+        state: { schema, tr }
+      } = createEditor(doc(p('<cursor>')));
       const newTr = removeParentNodeOfType(schema.nodes.table)(tr);
       expect(tr).toBe(newTr);
     });
     describe('when there is a p("one") before the table node and p("two") after', () => {
       it('should remove table and preserve p("one") and p("two")', () => {
-        const { state: { schema, tr } } = createEditor(
-          doc(p('one'), table(row(tdCursor)), p('two'))
-        );
+        const {
+          state: { schema, tr }
+        } = createEditor(doc(p('one'), table(row(tdCursor)), p('two')));
         const newTr = removeParentNodeOfType(schema.nodes.table)(tr);
         expect(newTr).not.toBe(tr);
-        toEqualDocument(newTr.doc, doc(p('one'), p('two')));
+        expect(newTr.doc).toEqualDocument(doc(p('one'), p('two')));
       });
     });
   });
 
   describe('replaceParentNodeOfType', () => {
     it('should return an original transaction if there is no parent node of a given NodeType', () => {
-      const { state: { schema, tr } } = createEditor(doc(p('<cursor>')));
+      const {
+        state: { schema, tr }
+      } = createEditor(doc(p('<cursor>')));
       const node = schema.nodes.paragraph.createChecked({}, schema.text('new'));
       const newTr = replaceParentNodeOfType(schema.nodes.table, node)(tr);
       expect(tr).toBe(newTr);
     });
     it('should return an original transaction if replacing is not possible', () => {
-      const { state: { schema, tr } } = createEditor(
-        doc(p('one'), table(row(tdCursor)), p('two'))
-      );
+      const {
+        state: { schema, tr }
+      } = createEditor(doc(p('one'), table(row(tdCursor)), p('two')));
       const node = schema.text('new');
       const newTr = replaceParentNodeOfType(schema.nodes.table, node)(tr);
       expect(tr).toBe(newTr);
     });
     describe('when there is a p("one") before the table node and p("two") after', () => {
       it('should replace table with p("new") and preserve p("one") and p("two")', () => {
-        const { state: { schema, tr } } = createEditor(
-          doc(p('one'), table(row(tdCursor)), p('two'))
-        );
+        const {
+          state: { schema, tr }
+        } = createEditor(doc(p('one'), table(row(tdCursor)), p('two')));
         const node = schema.nodes.paragraph.createChecked(
           {},
           schema.text('new')
         );
         const newTr = replaceParentNodeOfType(schema.nodes.table, node)(tr);
         expect(newTr).not.toBe(tr);
-        toEqualDocument(newTr.doc, doc(p('one'), p('new'), p('two')));
+        expect(newTr.doc).toEqualDocument(doc(p('one'), p('new'), p('two')));
       });
     });
     describe('when there are tree paragraphs', () => {
       it('should replace the middle paragraph with p("new") and preserve p("one") and p("two")', () => {
-        const { state: { schema, tr } } = createEditor(
-          doc(p('one'), p('hello<cursor>there'), p('two'))
-        );
+        const {
+          state: { schema, tr }
+        } = createEditor(doc(p('one'), p('hello<cursor>there'), p('two')));
         const node = schema.nodes.paragraph.createChecked(
           {},
           schema.text('new')
         );
         const newTr = replaceParentNodeOfType(schema.nodes.paragraph, node)(tr);
         expect(newTr).not.toBe(tr);
-        toEqualDocument(newTr.doc, doc(p('one'), p('new'), p('two')));
+        expect(newTr.doc).toEqualDocument(doc(p('one'), p('new'), p('two')));
       });
     });
     it('should be composable with other transforms', () => {
-      const { state: { schema, tr } } = createEditor(
+      const {
+        state: { schema, tr }
+      } = createEditor(
         doc(p('one'), table(row(td(p('hello<cursor>there')))), p('two'))
       );
       const { paragraph, table: tableNode } = schema.nodes;
@@ -99,28 +104,30 @@ describe('transforms', () => {
 
       const newTr = replaceParentNodeOfType(tableNode, node)(tr);
       expect(newTr).not.toBe(tr);
-      toEqualDocument(newTr.doc, doc(p('one'), p('new'), p('two')));
+      expect(newTr.doc).toEqualDocument(doc(p('one'), p('new'), p('two')));
 
       const newTr2 = removeParentNodeOfType(paragraph)(newTr);
       expect(newTr2).not.toBe(newTr);
-      toEqualDocument(newTr2.doc, doc(p('one'), p('new')));
+      expect(newTr2.doc).toEqualDocument(doc(p('one'), p('new')));
     });
   });
 
   describe('removeSelectedNode', () => {
     it('should return an original transaction if selection is not a NodeSelection', () => {
-      const { state: { tr } } = createEditor(doc(p('one')));
+      const {
+        state: { tr }
+      } = createEditor(doc(p('one')));
       const newTr = removeSelectedNode(tr);
       expect(newTr).toBe(tr);
     });
 
     it('should remove selected inline node', () => {
-      const { state: { tr } } = createEditor(
-        doc(p('one<node>', atomInline(), 'two'))
-      );
+      const {
+        state: { tr }
+      } = createEditor(doc(p('one<node>', atomInline(), 'two')));
       const newTr = removeSelectedNode(tr);
       expect(newTr).not.toBe(tr);
-      toEqualDocument(newTr.doc, doc(p('onetwo')));
+      expect(newTr.doc).toEqualDocument(doc(p('onetwo')));
     });
 
     it('should remove selected block node', () => {
@@ -128,117 +135,120 @@ describe('transforms', () => {
       const tr = state.tr.setSelection(NodeSelection.create(state.doc, 5));
       const newTr = removeSelectedNode(tr);
       expect(newTr).not.toBe(tr);
-      toEqualDocument(newTr.doc, doc(p('one'), p('two')));
+      expect(newTr.doc).toEqualDocument(doc(p('one'), p('two')));
     });
   });
 
   describe('safeInsert', () => {
     it('should insert a node if its allowed at the current cursor position', () => {
-      const { state: { schema, tr } } = createEditor(doc(p('one<cursor>')));
+      const {
+        state: { schema, tr }
+      } = createEditor(doc(p('one<cursor>')));
       const node = schema.nodes.atomInline.createChecked();
       const newTr = safeInsert(node)(tr);
       expect(newTr).not.toBe(tr);
-      toEqualDocument(newTr.doc, doc(p('one', atomInline())));
+      expect(newTr.doc).toEqualDocument(doc(p('one', atomInline())));
     });
 
     it('should insert a Fragment if its allowed at the current cursor position', () => {
-      const { state: { schema, tr } } = createEditor(doc(p('one<cursor>')));
+      const {
+        state: { schema, tr }
+      } = createEditor(doc(p('one<cursor>')));
       const node = schema.nodes.atomInline.createChecked();
       const newTr = safeInsert(Fragment.from(node))(tr);
       expect(newTr).not.toBe(tr);
-      toEqualDocument(newTr.doc, doc(p('one', atomInline())));
+      expect(newTr.doc).toEqualDocument(doc(p('one', atomInline())));
     });
 
     it('should insert a paragraph after the parent node if its not allowed at the cursor position and move cursor inside of the new paragraph', () => {
-      const { state: { schema, tr } } = createEditor(
-        doc(p(strong('zero'), 'o<cursor>ne'), p('three'))
-      );
+      const {
+        state: { schema, tr }
+      } = createEditor(doc(p(strong('zero'), 'o<cursor>ne'), p('three')));
       const node = schema.nodes.paragraph.createChecked({}, schema.text('two'));
       const newTr = safeInsert(node)(tr);
       expect(newTr).not.toBe(tr);
-      toEqualDocument(
-        newTr.doc,
+      expect(newTr.doc).toEqualDocument(
         doc(p(strong('zero'), 'one'), p('two'), p('three'))
       );
       expect(newTr.selection.$from.parent.textContent).toEqual('two');
     });
 
     it('should insert a Fragment after the parent node if its not allowed at the cursor position and move cursor inside of the new paragraph', () => {
-      const { state: { schema, tr } } = createEditor(
-        doc(p(strong('zero'), 'o<cursor>ne'), p('three'))
-      );
+      const {
+        state: { schema, tr }
+      } = createEditor(doc(p(strong('zero'), 'o<cursor>ne'), p('three')));
       const node = schema.nodes.paragraph.createChecked({}, schema.text('two'));
       const newTr = safeInsert(Fragment.from(node))(tr);
       expect(newTr).not.toBe(tr);
-      toEqualDocument(
-        newTr.doc,
+      expect(newTr.doc).toEqualDocument(
         doc(p(strong('zero'), 'one'), p('two'), p('three'))
       );
       expect(newTr.selection.$from.parent.textContent).toEqual('two');
     });
 
     it('should replace an empty parent paragraph with the given node', () => {
-      const { state: { schema, tr } } = createEditor(
-        doc(p('one'), p('<cursor>'), p('three'))
-      );
+      const {
+        state: { schema, tr }
+      } = createEditor(doc(p('one'), p('<cursor>'), p('three')));
       const node = schema.nodes.blockquote.createChecked(
         {},
         schema.nodes.paragraph.createChecked({}, schema.text('two'))
       );
       const newTr = safeInsert(Fragment.from(node))(tr);
       expect(newTr).not.toBe(tr);
-      toEqualDocument(
-        newTr.doc,
+      expect(newTr.doc).toEqualDocument(
         doc(p('one'), blockquote(p('two')), p('three'))
       );
       expect(newTr.selection.$from.parent.textContent).toEqual('two');
     });
 
     it('should insert a node at position 0 (start of the doc) and move cursor inside of the new paragraph', () => {
-      const { state: { schema, tr } } = createEditor(
-        doc(p('one'), p('two<cursor>'))
-      );
+      const {
+        state: { schema, tr }
+      } = createEditor(doc(p('one'), p('two<cursor>')));
       const node = schema.nodes.paragraph.createChecked({}, schema.text('new'));
       const newTr = safeInsert(node, 0)(tr);
       expect(newTr).not.toBe(tr);
-      toEqualDocument(newTr.doc, doc(p('new'), p('one'), p('two')));
+      expect(newTr.doc).toEqualDocument(doc(p('new'), p('one'), p('two')));
       expect(newTr.selection.$from.parent.textContent).toEqual('new');
     });
     it('should insert a Fragment at position 0 (start of the doc) and move cursor inside of the new paragraph', () => {
-      const { state: { schema, tr } } = createEditor(
-        doc(p('one'), p('two<cursor>'))
-      );
+      const {
+        state: { schema, tr }
+      } = createEditor(doc(p('one'), p('two<cursor>')));
       const node = schema.nodes.paragraph.createChecked({}, schema.text('new'));
       const newTr = safeInsert(Fragment.from(node), 0)(tr);
       expect(newTr).not.toBe(tr);
-      toEqualDocument(newTr.doc, doc(p('new'), p('one'), p('two')));
+      expect(newTr.doc).toEqualDocument(doc(p('new'), p('one'), p('two')));
       expect(newTr.selection.$from.parent.textContent).toEqual('new');
     });
     it('should insert a node at position 1 and move cursor inside of the new paragraph', () => {
-      const { state: { schema, tr } } = createEditor(
-        doc(p('one'), p('two<cursor>'))
-      );
+      const {
+        state: { schema, tr }
+      } = createEditor(doc(p('one'), p('two<cursor>')));
       const node = schema.nodes.paragraph.createChecked({}, schema.text('new'));
       const newTr = safeInsert(node, 1)(tr);
       expect(newTr).not.toBe(tr);
-      toEqualDocument(newTr.doc, doc(p('one'), p('new'), p('two')));
+      expect(newTr.doc).toEqualDocument(doc(p('one'), p('new'), p('two')));
       expect(newTr.selection.$from.parent.textContent).toEqual('new');
     });
     it('should insert a node at position in between two nodes and move cursor inside of the new paragraph', () => {
-      const { state: { schema, tr } } = createEditor(
-        doc(p('one'), p('two<cursor>'))
-      );
+      const {
+        state: { schema, tr }
+      } = createEditor(doc(p('one'), p('two<cursor>')));
       const node = schema.nodes.paragraph.createChecked({}, schema.text('new'));
       const newTr = safeInsert(node, 5)(tr);
       expect(newTr).not.toBe(tr);
-      toEqualDocument(newTr.doc, doc(p('one'), p('new'), p('two')));
+      expect(newTr.doc).toEqualDocument(doc(p('one'), p('new'), p('two')));
       expect(newTr.selection.$from.parent.textContent).toEqual('new');
     });
   });
 
   describe('replaceSelectedNode', () => {
     it('should return an original transaction if current selection is not a NodeSelection', () => {
-      const { state: { schema, tr } } = createEditor(doc(p('<cursor>')));
+      const {
+        state: { schema, tr }
+      } = createEditor(doc(p('<cursor>')));
       const node = schema.nodes.paragraph.createChecked({}, schema.text('new'));
       const newTr = replaceSelectedNode(node)(tr);
       expect(tr).toBe(newTr);
@@ -260,13 +270,15 @@ describe('transforms', () => {
       );
       const newTr = replaceSelectedNode(node)(tr);
       expect(newTr).not.toBe(tr);
-      toEqualDocument(newTr.doc, doc(p('one'), p('new'), p('two')));
+      expect(newTr.doc).toEqualDocument(doc(p('one'), p('new'), p('two')));
     });
   });
 
   describe('setParentNodeMarkup', () => {
     it('should return an original transaction if there is not parent node of a given nodeType', () => {
-      const { state: { schema, tr } } = createEditor(doc(p('<cursor>')));
+      const {
+        state: { schema, tr }
+      } = createEditor(doc(p('<cursor>')));
       const newTr = setParentNodeMarkup(
         schema.nodes.blockquote,
         schema.nodes.paragraph
@@ -275,20 +287,24 @@ describe('transforms', () => {
     });
 
     it('should update nodeType', () => {
-      const { state: { schema, tr } } = createEditor(
-        doc(table(row(td(p('text<cursor>')))))
-      );
+      const {
+        state: { schema, tr }
+      } = createEditor(doc(table(row(td(p('text<cursor>'))))));
       const newTr = setParentNodeMarkup(
         schema.nodes.table_cell,
         schema.nodes.table_header
       )(tr);
       expect(newTr).not.toBe(tr);
-      toEqualDocument(newTr.doc, doc(table(row(th(p('text'))))));
+      expect(newTr.doc).toEqualDocument(doc(table(row(th(p('text'))))));
     });
 
     it('should update attributes', () => {
       const { state } = createEditor(doc(table(row(td(p('text<cursor>'))))));
-      const { schema: { nodes: { table_cell } } } = state;
+      const {
+        schema: {
+          nodes: { table_cell }
+        }
+      } = state;
       const newTr = setParentNodeMarkup(table_cell, null, {
         colspan: 5,
         rowspan: 7
@@ -316,19 +332,28 @@ describe('transforms', () => {
       expect(tr).toBe(newTr);
     });
     it('should return an original transaction if there is no parent node of a given `nodeType`', () => {
-      const { state: { tr, schema } } = createEditor(doc(p('one')));
+      const {
+        state: { tr, schema }
+      } = createEditor(doc(p('one')));
       const newTr = selectParentNodeOfType(schema.nodes.table)(tr);
       expect(tr).toBe(newTr);
     });
     it('should return a new transaction that selects a parent node of a given `nodeType`', () => {
-      const { state: { tr, schema } } = createEditor(doc(p('one')));
+      const {
+        state: { tr, schema }
+      } = createEditor(doc(p('one')));
       const newTr = selectParentNodeOfType(schema.nodes.paragraph)(tr);
       expect(newTr).not.toBe(tr);
       expect(newTr.selection.node.type.name).toEqual('paragraph');
     });
     it('should return a new transaction that selects a parent node of a given `nodeType`, if `nodeType` an array', () => {
       const {
-        state: { tr, schema: { nodes: { paragraph, table } } }
+        state: {
+          tr,
+          schema: {
+            nodes: { paragraph, table }
+          }
+        }
       } = createEditor(doc(p('one')));
       const newTr = selectParentNodeOfType([table, paragraph])(tr);
       expect(newTr).not.toBe(tr);
@@ -338,33 +363,37 @@ describe('transforms', () => {
 
   describe('removeNodeBefore', () => {
     it('should return an original transaction if there is no nodeBefore', () => {
-      const { state: { tr } } = createEditor(doc(p('<cursor>')));
+      const {
+        state: { tr }
+      } = createEditor(doc(p('<cursor>')));
       const newTr = removeNodeBefore(tr);
       expect(tr).toBe(newTr);
     });
     it('should a new transaction that removes nodeBefore if its a table', () => {
-      const { state: { tr } } = createEditor(
+      const {
+        state: { tr }
+      } = createEditor(
         doc(p('one'), table(row(tdEmpty), row(tdEmpty)), '<cursor>', p('two'))
       );
       const newTr = removeNodeBefore(tr);
       expect(newTr).not.toBe(tr);
-      toEqualDocument(newTr.doc, doc(p('one'), p('two')));
+      expect(newTr.doc).toEqualDocument(doc(p('one'), p('two')));
     });
     it('should a new transaction that removes nodeBefore if its a blockquote', () => {
-      const { state: { tr } } = createEditor(
-        doc(p('one'), blockquote(p('')), '<cursor>', p('two'))
-      );
+      const {
+        state: { tr }
+      } = createEditor(doc(p('one'), blockquote(p('')), '<cursor>', p('two')));
       const newTr = removeNodeBefore(tr);
       expect(newTr).not.toBe(tr);
-      toEqualDocument(newTr.doc, doc(p('one'), p('two')));
+      expect(newTr.doc).toEqualDocument(doc(p('one'), p('two')));
     });
     it('should a new transaction that removes nodeBefore if its a leaf node', () => {
-      const { state: { tr } } = createEditor(
-        doc(p('one'), atomBlock(), '<cursor>', p('two'))
-      );
+      const {
+        state: { tr }
+      } = createEditor(doc(p('one'), atomBlock(), '<cursor>', p('two')));
       const newTr = removeNodeBefore(tr);
       expect(newTr).not.toBe(tr);
-      toEqualDocument(newTr.doc, doc(p('one'), p('two')));
+      expect(newTr.doc).toEqualDocument(doc(p('one'), p('two')));
     });
   });
 });

--- a/jestFrameworkSetup.js
+++ b/jestFrameworkSetup.js
@@ -1,0 +1,35 @@
+const diff = require('./node_modules/jest-diff');
+
+expect.extend({
+  toEqualDocument(actual, expected) {
+    const pass = this.equals(actual.toJSON(), expected.toJSON());
+    const message = pass
+      ? () =>
+          `${this.utils.matcherHint('.not.toEqualDocument')}\n\n` +
+          `Expected JSON value of document to not equal:\n  ${this.utils.printExpected(
+            expected
+          )}\n` +
+          `Actual JSON:\n  ${this.utils.printReceived(actual)}`
+      : () => {
+          const diffString = diff(expected, actual, {
+            expand: this.expand
+          });
+          return (
+            `${this.utils.matcherHint('.toEqualDocument')}\n\n` +
+            `Expected JSON value of document to equal:\n${this.utils.printExpected(
+              expected
+            )}\n` +
+            `Actual JSON:\n  ${this.utils.printReceived(actual)}` +
+            `${diffString ? `\n\nDifference:\n\n${diffString}` : ''}`
+          );
+        };
+
+    return {
+      pass,
+      actual,
+      expected,
+      message,
+      name: 'toEqualDocument'
+    };
+  }
+});

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
   "jest": {
     "transform": {
       "^.+\\.js$": "babel-jest"
-    }
+    },
+    "setupTestFrameworkScriptFile": "./jestFrameworkSetup.js"
   },
   "typings": "typings.d.ts",
   "files": [

--- a/test-helpers/index.js
+++ b/test-helpers/index.js
@@ -71,7 +71,3 @@ testHelpers.createEditor = doc => {
 
   return { state, view };
 };
-
-testHelpers.toEqualDocument = (actual, expected) => {
-  expect(actual.toJSON()).toEqual(expected.toJSON());
-};


### PR DESCRIPTION
This PR moves `toEqualDocument` from test helpers to jest config file