### PR TITLE
fix: set cursor inside of the replaced node after calling replacePare…

### DIFF
--- a/__tests__/transforms.js
+++ b/__tests__/transforms.js
@@ -67,7 +67,7 @@ describe('transforms', () => {
       expect(tr).toBe(newTr);
     });
     describe('when there is a p("one") before the table node and p("two") after', () => {
-      it('should replace table with p("new") and preserve p("one") and p("two")', () => {
+      it('should replace table with p("new"), preserve p("one") and p("two"), and put cursor inside of the new node', () => {
         const {
           state: { schema, tr }
         } = createEditor(doc(p('one'), table(row(tdCursor)), p('two')));
@@ -78,10 +78,11 @@ describe('transforms', () => {
         const newTr = replaceParentNodeOfType(schema.nodes.table, node)(tr);
         expect(newTr).not.toBe(tr);
         expect(newTr.doc).toEqualDocument(doc(p('one'), p('new'), p('two')));
+        expect(newTr.selection.$from.pos).toEqual(9);
       });
     });
     describe('when there are tree paragraphs', () => {
-      it('should replace the middle paragraph with p("new") and preserve p("one") and p("two")', () => {
+      it('should replace the middle paragraph with p("new"), preserve p("one") and p("two"), and put cursor inside of the new node', () => {
         const {
           state: { schema, tr }
         } = createEditor(doc(p('one'), p('hello<cursor>there'), p('two')));
@@ -92,6 +93,7 @@ describe('transforms', () => {
         const newTr = replaceParentNodeOfType(schema.nodes.paragraph, node)(tr);
         expect(newTr).not.toBe(tr);
         expect(newTr.doc).toEqualDocument(doc(p('one'), p('new'), p('two')));
+        expect(newTr.selection.$from.pos).toEqual(9);
       });
     });
     it('should be composable with other transforms', () => {
@@ -109,7 +111,7 @@ describe('transforms', () => {
 
       const newTr2 = removeParentNodeOfType(paragraph)(newTr);
       expect(newTr2).not.toBe(newTr);
-      expect(newTr2.doc).toEqualDocument(doc(p('one'), p('new')));
+      expect(newTr2.doc).toEqualDocument(doc(p('one'), p('two')));
     });
   });
 

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,5 +1,6 @@
 import { NodeSelection } from 'prosemirror-state';
 import { Fragment, Node as PMNode } from 'prosemirror-model';
+import { setTextSelection } from './transforms';
 
 // :: (selection: Selection) → boolean
 // Checks if current selection is a `NodeSelection`.
@@ -37,7 +38,8 @@ export const replaceNodeAtPos = (position, content) => tr => {
   const node = tr.doc.nodeAt(before);
   const $pos = tr.doc.resolve(before);
   if (canReplace($pos, content)) {
-    return cloneTr(tr.replaceWith(before, before + node.nodeSize, content));
+    tr = tr.replaceWith(before, before + node.nodeSize, content);
+    return cloneTr(setTextSelection(tr.selection.$from.pos - 1, -1)(tr));
   }
   return tr;
 };


### PR DESCRIPTION
Currently it set a wrong cursor position after replacing parent node (actually its a default PM behaviour). I need it to be inside of the replaced node.