### PR TITLE
fix: replaceParentNodeOfType try to replace all given nodeTypes

### DIFF
--- a/__tests__/transforms.js
+++ b/__tests__/transforms.js
@@ -111,6 +111,18 @@ describe('transforms', () => {
       expect(newTr2).not.toBe(newTr);
       expect(newTr2.doc).toEqualDocument(doc(p('one'), p('new')));
     });
+
+    it('should replace parent if array of nodeTypes is given', () => {
+      const {
+        state: { schema, tr }
+      } = createEditor(doc(p('one'), blockquote(p('two<cursor>')), p('three')));
+      const { paragraph, blockquote: quote } = schema.nodes;
+      const node = paragraph.createChecked({}, schema.text('new'));
+
+      const newTr = replaceParentNodeOfType([quote, paragraph], node)(tr);
+      expect(newTr).not.toBe(tr);
+      expect(newTr.doc).toEqualDocument(doc(p('one'), p('new'), p('three')));
+    });
   });
 
   describe('removeSelectedNode', () => {

--- a/src/transforms.js
+++ b/src/transforms.js
@@ -36,9 +36,17 @@ export const removeParentNodeOfType = nodeType => tr => {
 // );
 // ```
 export const replaceParentNodeOfType = (nodeType, content) => tr => {
-  const parent = findParentNodeOfType(nodeType)(tr.selection);
-  if (parent) {
-    return replaceNodeAtPos(parent.pos, content)(tr);
+  if (!Array.isArray(nodeType)) {
+    nodeType = [nodeType];
+  }
+  for (let i = 0, count = nodeType.length; i < count; i++) {
+    const parent = findParentNodeOfType(nodeType[i])(tr.selection);
+    if (parent) {
+      const newTr = replaceNodeAtPos(parent.pos, content)(tr);
+      if (newTr !== tr) {
+        return newTr;
+      }
+    }
   }
   return tr;
 };


### PR DESCRIPTION
Currently `replaceParentNodeOfType` fails to replace all of the 

