### PR TITLE
fix: getCellsInColumn and getCellsInRow to return start pos instead o…

### DIFF
--- a/__tests__/table.js
+++ b/__tests__/table.js
@@ -158,8 +158,8 @@ describe('table', () => {
         expect(cell.node.textContent).toEqual(`${i + 1}`);
         expect(typeof cell.pos).toEqual('number');
       });
-      expect(cells[0].pos).toEqual(2);
-      expect(cells[1].pos).toEqual(17);
+      expect(cells[0].pos).toEqual(3);
+      expect(cells[1].pos).toEqual(18);
     });
   });
 
@@ -187,9 +187,9 @@ describe('table', () => {
         expect(cell.node.textContent).toEqual(`${i + 1}`);
         expect(typeof cell.pos).toEqual('number');
       });
-      expect(cells[0].pos).toEqual(2);
-      expect(cells[1].pos).toEqual(7);
-      expect(cells[2].pos).toEqual(12);
+      expect(cells[0].pos).toEqual(3);
+      expect(cells[1].pos).toEqual(8);
+      expect(cells[2].pos).toEqual(13);
     });
   });
 
@@ -217,12 +217,12 @@ describe('table', () => {
         expect(cell.node.textContent).toEqual(`${i + 1}`);
         expect(typeof cell.pos).toEqual('number');
       });
-      expect(cells[0].pos).toEqual(2);
-      expect(cells[1].pos).toEqual(7);
-      expect(cells[2].pos).toEqual(12);
-      expect(cells[3].pos).toEqual(19);
-      expect(cells[4].pos).toEqual(24);
-      expect(cells[5].pos).toEqual(29);
+      expect(cells[0].pos).toEqual(3);
+      expect(cells[1].pos).toEqual(8);
+      expect(cells[2].pos).toEqual(13);
+      expect(cells[3].pos).toEqual(20);
+      expect(cells[4].pos).toEqual(25);
+      expect(cells[5].pos).toEqual(30);
     });
   });
 

--- a/src/table.js
+++ b/src/table.js
@@ -116,7 +116,7 @@ export const getCellsInColumn = columnIndex => selection => {
       });
       return cells.map(pos => {
         const node = table.node.nodeAt(pos);
-        return { pos: pos + table.pos, node };
+        return { pos: pos + table.pos + 1, node };
       });
     }
   }
@@ -141,7 +141,7 @@ export const getCellsInRow = rowIndex => selection => {
       });
       return cells.map(pos => {
         const node = table.node.nodeAt(pos);
-        return { pos: pos + table.pos, node };
+        return { pos: pos + table.pos + 1, node };
       });
     }
   }
@@ -165,7 +165,7 @@ export const getCellsInTable = selection => {
     });
     return cells.map(pos => {
       const node = table.node.nodeAt(pos);
-      return { pos: pos + table.pos, node };
+      return { pos: pos + table.pos + 1, node };
     });
   }
 };
@@ -181,8 +181,8 @@ export const getCellsInTable = selection => {
 export const selectColumn = columnIndex => tr => {
   const cells = getCellsInColumn(columnIndex)(tr.selection);
   if (cells) {
-    const $anchor = tr.doc.resolve(cells[0].pos);
-    const $head = tr.doc.resolve(cells[cells.length - 1].pos);
+    const $anchor = tr.doc.resolve(cells[0].pos - 1);
+    const $head = tr.doc.resolve(cells[cells.length - 1].pos - 1);
     return cloneTr(tr.setSelection(new CellSelection($anchor, $head)));
   }
   return tr;
@@ -199,8 +199,8 @@ export const selectColumn = columnIndex => tr => {
 export const selectRow = rowIndex => tr => {
   const cells = getCellsInRow(rowIndex)(tr.selection);
   if (cells) {
-    const $anchor = tr.doc.resolve(cells[0].pos);
-    const $head = tr.doc.resolve(cells[cells.length - 1].pos);
+    const $anchor = tr.doc.resolve(cells[0].pos - 1);
+    const $head = tr.doc.resolve(cells[cells.length - 1].pos - 1);
     return cloneTr(tr.setSelection(new CellSelection($anchor, $head)));
   }
   return tr;
@@ -217,8 +217,8 @@ export const selectRow = rowIndex => tr => {
 export const selectTable = tr => {
   const cells = getCellsInTable(tr.selection);
   if (cells) {
-    const $anchor = tr.doc.resolve(cells[0].pos);
-    const $head = tr.doc.resolve(cells[cells.length - 1].pos);
+    const $anchor = tr.doc.resolve(cells[0].pos - 1);
+    const $head = tr.doc.resolve(cells[cells.length - 1].pos - 1);
     return cloneTr(tr.setSelection(new CellSelection($anchor, $head)));
   }
   return tr;


### PR DESCRIPTION
`getCellsInColumn` and `getCellsInRow` utils are supposed to return start position of cells instead of the position directly before the cell.