### PR TITLE
Remove position mapping from table utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,7 +424,7 @@ npm install prosemirror-utils
 
    ```javascript
    dispatch(
-     forEachCellInColumn(0, cell => emptyCell(cell, state.schema))(state.tr)
+     forEachCellInColumn(0, (cell, tr) => emptyCell(cell, state.schema)(tr))(state.tr)
    );
    ```
 
@@ -436,7 +436,7 @@ npm install prosemirror-utils
 
    ```javascript
    dispatch(
-     forEachCellInRow(0, cell => setCellAttrs(cell, { background: 'red' }))(state.tr)
+     forEachCellInRow(0, (cell, tr) => setCellAttrs(cell, { background: 'red' })(tr))(state.tr)
    );
    ```
 

--- a/__tests__/table.js
+++ b/__tests__/table.js
@@ -319,11 +319,9 @@ describe('table', () => {
           table(row(td(p('one one')), tdEmpty), row(td(p('two two')), tdEmpty))
         )
       );
-      let newTr;
-      const cells = getCellsInColumn(0)(tr.selection);
-      cells.forEach(cell => {
-        newTr = emptyCell(cell, schema)(tr);
-      });
+      const newTr = forEachCellInColumn(0, (cell, tr) =>
+        emptyCell(cell, schema)(tr)
+      )(tr);
       expect(newTr).not.toBe(tr);
       expect(newTr.doc).toEqualDocument(
         doc(table(row(tdEmpty, tdEmpty), row(tdEmpty, tdEmpty)))
@@ -937,7 +935,7 @@ describe('table', () => {
         );
         const newTr = forEachCellInColumn(
           0,
-          cell => emptyCell(cell, schema),
+          (cell, tr) => emptyCell(cell, schema)(tr),
           true
         )(tr);
         expect(newTr).not.toBe(tr);
@@ -959,7 +957,7 @@ describe('table', () => {
         );
         const newTr = forEachCellInColumn(
           0,
-          cell => setCellAttrs(cell, { ugly: true }),
+          (cell, tr) => setCellAttrs(cell, { ugly: true })(tr),
           true
         )(tr);
         expect(newTr).not.toBe(tr);
@@ -988,7 +986,7 @@ describe('table', () => {
         );
         const newTr = forEachCellInColumn(
           0,
-          cell => emptyCell(cell, schema),
+          (cell, tr) => emptyCell(cell, schema)(tr),
           true
         )(tr);
         expect(newTr).not.toBe(tr);
@@ -1012,7 +1010,7 @@ describe('table', () => {
         );
         const newTr = forEachCellInColumn(
           0,
-          cell => emptyCell(cell, schema),
+          (cell, tr) => emptyCell(cell, schema)(tr),
           true
         )(tr);
         expect(newTr).not.toBe(tr);
@@ -1044,7 +1042,7 @@ describe('table', () => {
         );
         const newTr = forEachCellInRow(
           0,
-          cell => emptyCell(cell, schema),
+          (cell, tr) => emptyCell(cell, schema)(tr),
           true
         )(tr);
         expect(newTr).not.toBe(tr);
@@ -1061,7 +1059,7 @@ describe('table', () => {
         );
         const newTr = forEachCellInRow(
           0,
-          cell => setCellAttrs(cell, { ugly: true }),
+          (cell, tr) => setCellAttrs(cell, { ugly: true })(tr),
           true
         )(tr);
         expect(newTr).not.toBe(tr);
@@ -1090,7 +1088,7 @@ describe('table', () => {
         );
         const newTr = forEachCellInRow(
           0,
-          cell => emptyCell(cell, schema),
+          (cell, tr) => emptyCell(cell, schema)(tr),
           true
         )(tr);
         expect(newTr).not.toBe(tr);
@@ -1119,7 +1117,7 @@ describe('table', () => {
         );
         const newTr = forEachCellInRow(
           0,
-          cell => emptyCell(cell, schema),
+          (cell, tr) => emptyCell(cell, schema)(tr),
           true
         )(tr);
         expect(newTr).not.toBe(tr);

--- a/src/table.js
+++ b/src/table.js
@@ -239,8 +239,8 @@ export const emptyCell = (cell, schema) => tr => {
     const content = tableNodeTypes(schema).cell.createAndFill().content;
     if (!cell.node.content.eq(content)) {
       tr.replaceWith(
-        tr.mapping.map(cell.pos - 1),
-        tr.mapping.map(cell.pos + cell.node.nodeSize - 2),
+        cell.pos - 1,
+        cell.pos + cell.node.nodeSize - 2,
         new Slice(content, 0, 0)
       );
       return cloneTr(tr);
@@ -484,7 +484,7 @@ export const removeRowClosestToPos = $pos => tr => {
 //
 // ```javascript
 // dispatch(
-//   forEachCellInColumn(0, cell => emptyCell(cell, state.schema))(state.tr)
+//   forEachCellInColumn(0, (cell, tr) => emptyCell(cell, state.schema)(tr))(state.tr)
 // );
 // ```
 export const forEachCellInColumn = (
@@ -494,9 +494,9 @@ export const forEachCellInColumn = (
 ) => tr => {
   const cells = getCellsInColumn(columnIndex)(tr.selection);
   if (cells) {
-    cells.forEach(cell => {
-      tr = cellTransform(cell)(tr);
-    });
+    for (let i = cells.length - 1; i >= 0; i--) {
+      tr = cellTransform(cells[i], tr);
+    }
     if (setCursorToLastCell) {
       const $pos = tr.doc.resolve(
         tr.mapping.map(cells[cells.length - 1].pos - 1)
@@ -514,7 +514,7 @@ export const forEachCellInColumn = (
 //
 // ```javascript
 // dispatch(
-//   forEachCellInRow(0, cell => setCellAttrs(cell, { background: 'red' }))(state.tr)
+//   forEachCellInRow(0, (cell, tr) => setCellAttrs(cell, { background: 'red' })(tr))(state.tr)
 // );
 // ```
 export const forEachCellInRow = (
@@ -524,9 +524,9 @@ export const forEachCellInRow = (
 ) => tr => {
   const cells = getCellsInRow(rowIndex)(tr.selection);
   if (cells) {
-    cells.forEach(cell => {
-      tr = cellTransform(cell)(tr);
-    });
+    for (let i = cells.length - 1; i >= 0; i--) {
+      tr = cellTransform(cells[i], tr);
+    }
     if (setCursorToLastCell) {
       const $pos = tr.doc.resolve(
         tr.mapping.map(cells[cells.length - 1].pos - 1)
@@ -548,7 +548,7 @@ export const forEachCellInRow = (
 export const setCellAttrs = (cell, attrs) => tr => {
   if (cell) {
     tr.setNodeMarkup(
-      tr.mapping.map(cell.pos - 1),
+      cell.pos - 1,
       null,
       Object.assign({}, cell.node.attrs, attrs)
     );


### PR DESCRIPTION
- something I realised during shipit: we shouldn't map positions inside of the utils, because it makes utils impossible to use in a chain.
- changed `forEachCellInRow` and `forEachCellInColumn`: passing `tr` to the second argument to make it more explicit how that works