### PR TITLE
fix: safeInsert - move cursor inside inserted node

### DIFF
--- a/__tests__/transforms.js
+++ b/__tests__/transforms.js
@@ -25,7 +25,8 @@ import {
   replaceSelectedNode,
   setParentNodeMarkup,
   selectParentNodeOfType,
-  removeNodeBefore
+  removeNodeBefore,
+  createTable
 } from '../src';
 
 describe('transforms', () => {
@@ -383,10 +384,10 @@ describe('transforms', () => {
         expect(newTr.doc).toEqualDocument(doc(p('new')));
         expect(newTr.selection.head).toEqual(4);
       });
-      it('should set the selection after the inserted content (block)', () => {
+      it('should move cursor to the inserted paragraph', () => {
         const {
           state: { schema, tr }
-        } = createEditor(doc(p('old<cursor>')));
+        } = createEditor(doc(p('ol<cursor>d')));
         const node = schema.nodes.paragraph.createChecked(
           {},
           schema.text('new')
@@ -394,7 +395,26 @@ describe('transforms', () => {
         const newTr = safeInsert(node)(tr);
         expect(newTr).not.toBe(tr);
         expect(newTr.doc).toEqualDocument(doc(p('old'), p('new')));
-        expect(newTr.selection.head).toEqual(9);
+        expect(newTr.selection.head).toEqual(6);
+      });
+      it('should move cursor to the first cell of the inserted table', () => {
+        const {
+          state: { schema, tr }
+        } = createEditor(doc(p('tex<cursor>t')));
+        const node = createTable(schema);
+        const newTr = safeInsert(node)(tr);
+        expect(newTr).not.toBe(tr);
+        expect(newTr.doc).toEqualDocument(
+          doc(
+            p('text'),
+            table(
+              row(th(p('')), th(p('')), th(p(''))),
+              row(td(p('')), td(p('')), td(p(''))),
+              row(td(p('')), td(p('')), td(p('')))
+            )
+          )
+        );
+        expect(newTr.selection.head).toEqual(10);
       });
     });
   });

--- a/src/transforms.js
+++ b/src/transforms.js
@@ -154,7 +154,7 @@ export const safeInsert = (content, position) => tr => {
     const $pos = tr.doc.resolve(pos);
     if (canInsert($pos, content)) {
       tr.insert(pos, content);
-      return cloneTr(setTextSelection(tr.mapping.map(pos), -1)(tr));
+      return cloneTr(setTextSelection(pos)(tr));
     }
   }
   return tr;


### PR DESCRIPTION
it doesn't put cursor correctly when appending nodes