### PR TITLE
fix readme and typings

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,8 +416,7 @@ npm install prosemirror-utils
    ```
 
 
- * **`forEachCellInColumn`**`(columnIndex: number, cellTransform: fn(cell: {pos: number, start: number, node: ProseMirrorNode}) → fn(tr: Transaction))`\
-   , setCursorToLastCell: ?boolean) → (tr: Transaction) → Transaction
+ * **`forEachCellInColumn`**`(columnIndex: number, cellTransform: fn(cell: {pos: number, start: number, node: ProseMirrorNode}, tr: Transaction) → Transaction, setCursorToLastCell: ?boolean) → fn(tr: Transaction) → Transaction`\
    Returns a new transaction that maps a given `cellTransform` function to each cell in a column at a given `columnIndex`.
    It will set the selection into the last cell of the column if `setCursorToLastCell` param is set to `true`.
 
@@ -428,8 +427,7 @@ npm install prosemirror-utils
    ```
 
 
- * **`forEachCellInRow`**`(rowIndex: number, cellTransform: fn(cell: {pos: number, start: number, node: ProseMirrorNode}) → fn(tr: Transaction))`\
-   , setCursorToLastCell: ?boolean) → (tr: Transaction) → Transaction
+ * **`forEachCellInRow`**`(rowIndex: number, cellTransform: fn(cell: {pos: number, start: number, node: ProseMirrorNode}, tr: Transaction) → Transaction, setCursorToLastCell: ?boolean) → fn(tr: Transaction) → Transaction`\
    Returns a new transaction that maps a given `cellTransform` function to each cell in a row at a given `rowIndex`.
    It will set the selection into the last cell of the row if `setCursorToLastCell` param is set to `true`.
 

--- a/src/table.js
+++ b/src/table.js
@@ -482,7 +482,7 @@ export const removeRowClosestToPos = $pos => tr => {
   return tr;
 };
 
-// :: (columnIndex: number, cellTransform: (cell: {pos: number, start: number, node: ProseMirrorNode}) → (tr: Transaction)), setCursorToLastCell: ?boolean) → (tr: Transaction) → Transaction
+// :: (columnIndex: number, cellTransform: (cell: {pos: number, start: number, node: ProseMirrorNode}, tr: Transaction) → Transaction, setCursorToLastCell: ?boolean) → (tr: Transaction) → Transaction
 // Returns a new transaction that maps a given `cellTransform` function to each cell in a column at a given `columnIndex`.
 // It will set the selection into the last cell of the column if `setCursorToLastCell` param is set to `true`.
 //
@@ -510,7 +510,7 @@ export const forEachCellInColumn = (
   return tr;
 };
 
-// :: (rowIndex: number, cellTransform: (cell: {pos: number, start: number, node: ProseMirrorNode}) → (tr: Transaction)), setCursorToLastCell: ?boolean) → (tr: Transaction) → Transaction
+// :: (rowIndex: number, cellTransform: (cell: {pos: number, start: number, node: ProseMirrorNode}, tr: Transaction) → Transaction, setCursorToLastCell: ?boolean) → (tr: Transaction) → Transaction
 // Returns a new transaction that maps a given `cellTransform` function to each cell in a row at a given `rowIndex`.
 // It will set the selection into the last cell of the row if `setCursorToLastCell` param is set to `true`.
 //

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -9,7 +9,7 @@ export type ContentNodeWithPos = {pos: number, start: number, node: ProsemirrorN
 
 export type NodeWithPos = {pos: number, node: ProsemirrorNode};
 
-export type CellTransform = (cell: NodeWithPos) => (tr: Transaction) => Transaction;
+export type CellTransform = (cell: NodeWithPos, tr: Transaction) => Transaction;
 
 // Selection
 export function findParentNode(predicate: Predicate): (selection: Selection) => ContentNodeWithPos | undefined;


### PR DESCRIPTION
updated readme and typings of `forEachCellInColumn` and `forEachCellInRow` to align with the code