### PR TITLE
Loosen prosemirror-tables dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5800,9 +5800,9 @@
       }
     },
     "prosemirror-tables": {
-      "version": "0.6.5",
-      "resolved": "http://registry.npmjs.org/prosemirror-tables/-/prosemirror-tables-0.6.5.tgz",
-      "integrity": "sha1-qZ9QikQAEiTZ0asDXcYClJabvS4=",
+      "version": "0.7.9",
+      "resolved": "https://registry.npmjs.org/prosemirror-tables/-/prosemirror-tables-0.7.9.tgz",
+      "integrity": "sha512-wCYnDdYMJPD3OdbBqn+Lv+lr4jL4scUTdP+ICSQpqLuvj7seFcTIRBw2o5yUW/ZaMQ5v9TqhFbicb8k/3wj8eg==",
       "dev": true,
       "requires": {
         "prosemirror-keymap": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "peerDependencies": {
     "prosemirror-model": "^1.0.0",
     "prosemirror-state": "^1.0.1",
-    "prosemirror-tables": "^0.6.5"
+    "prosemirror-tables": "^0.7.9"
   },
   "devDependencies": {
     "babel-core": "^6.26.0",
@@ -63,7 +63,7 @@
     "prosemirror-model": "^1.0.0",
     "prosemirror-schema-basic": "^1.0.0",
     "prosemirror-state": "^1.0.1",
-    "prosemirror-tables": "^0.6.5",
+    "prosemirror-tables": "^0.7.9",
     "prosemirror-test-builder": "^1.0.1",
     "prosemirror-view": "^1.1.1",
     "rollup": "^0.56.3",


### PR DESCRIPTION
I wasn't able to use `tiptap` because `yarn check` was outputting this error:

```
error "tiptap-utils#prosemirror-utils#prosemirror-tables@^0.6.5" doesn't satisfy found match of "prosemirror-tables@0.7.7"
```

The underlying reason is that `tiptap@0.17.0` depends on `tiptap-utils@^0.3.0`, which depends on `prosemirror-tables ^0.7.7`, _and_ on `prosemirror-utils ^0.6.6`, which (as seen below) currently depends on `prosemirror-tables ^0.6.5`. These `prosemirror-tables` dependencies are incompatible.