### PR TITLE
59: findDomRefAtPos should always return a DOM node. If cursor is poi…

### DIFF
--- a/__tests__/selection.js
+++ b/__tests__/selection.js
@@ -355,10 +355,10 @@ describe('selection', () => {
       expect(ref instanceof HTMLParagraphElement).toBe(true);
     });
 
-    it('should return DOM reference of a text node when offset>0', () => {
+    it('should return DOM reference of a paragraph if cursor is inside of a text node', () => {
       const { view } = createEditor(doc(p(atomInline(), 'text')));
       const ref = findDomRefAtPos(3, view.domAtPos.bind(view));
-      expect(ref instanceof Text).toBe(true);
+      expect(ref instanceof HTMLParagraphElement).toBe(true);
     });
   });
 });

--- a/src/selection.js
+++ b/src/selection.js
@@ -167,5 +167,14 @@ export const findPositionOfNodeBefore = selection => {
 export const findDomRefAtPos = (position, domAtPos) => {
   const dom = domAtPos(position);
   const node = dom.node.childNodes[dom.offset];
-  return node && node.nodeType !== Node.TEXT_NODE ? node : dom.node;
+
+  if (dom.node.nodeType === Node.TEXT_NODE) {
+    return dom.node.parentNode;
+  }
+
+  if (!node || node.nodeType === Node.TEXT_NODE) {
+    return dom.node;
+  }
+
+  return node;
 };


### PR DESCRIPTION
See #59 