### PR TITLE
Add move columns and rows util function

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,6 +328,257 @@ npm install prosemirror-utils
    ```
 
 
+ * **`moveRow`**`(originRowIndex: number, targetRowIndex: targetColumnIndex, options: ?MovementOptions) → fn(tr: Transaction) → Transaction`\
+   Returns a new transaction that moves the origin row to the target index;
+
+   by default "tryToFit" is false, that means if you try to move a row to a place
+   where we will need to split a row with merged cells it'll throw an exception, for example:
+
+        ____________________________
+       |      |      |             |
+    0  |  A1  |  B1  |     C1      |
+       |______|______|______ ______|
+       |      |             |      |
+    1  |  A2  |     B2      |      |
+       |______|______ ______|      |
+       |      |      |      |  D1  |
+    2  |  A3  |  B3  |  C2  |      |
+       |______|______|______|______|
+
+   if you try to move the row 0 to the row index 1 with tryToFit false,
+   it'll throw an exception since you can't split the row 1;
+   but if "tryToFit" is true, it'll move the row using the current direction.
+
+   We defined current direction using the target and origin values
+   if the origin is greater than the target, that means the course is `bottom-to-top`,
+   so the `tryToFit` logic will use this direction to determine
+   if we should move the column to the right or the left.
+
+   for example, if you call the function using `moveRow(0, 1, { tryToFit: true })`
+   the result will be:
+        ____________________________
+       |      |             |      |
+    0  |  A2  |     B2      |      |
+       |______|______ ______|      |
+       |      |      |      |  D1  |
+    1  |  A3  |  B3  |  C2  |      |
+       |______|______|______|______|
+       |      |      |             |
+    2  |  A1  |  B1  |     C1      |
+       |______|______|______ ______|
+
+   since we could put the row zero on index one,
+   we pushed to the best place to fit the row index 0,
+   in this case, row index 2.
+
+
+   -------- HOW TO OVERRIDE DIRECTION --------
+
+   If you set "tryToFit" to "true", it will try to figure out the best direction
+   place to fit using the origin and target index, for example:
+
+
+        ____________________________
+       |      |      |             |
+    0  |  A1  |  B1  |     C1      |
+       |______|______|______ ______|
+       |      |             |      |
+    1  |  A2  |     B2      |      |
+       |______|______ ______|      |
+       |      |      |      |  D1  |
+    2  |  A3  |  B3  |  C2  |      |
+       |______|______|______|______|
+       |      |             |      |
+    3  |  A4  |     B4      |      |
+       |______|______ ______|      |
+       |      |      |      |  D2  |
+    4  |  A5  |  B5  |  C3  |      |
+       |______|______|______|______|
+
+
+   If you try to move the row 0 to row index 4 with "tryToFit" enabled, by default,
+   the code will put it on after the merged rows,
+   but you can override it using the "direction" option.
+
+   -1: Always put the origin before the target
+        ____________________________
+       |      |             |      |
+    0  |  A2  |     B2      |      |
+       |______|______ ______|      |
+       |      |      |      |  D1  |
+    1  |  A3  |  B3  |  C2  |      |
+       |______|______|______|______|
+       |      |      |             |
+    2  |  A1  |  B1  |     C1      |
+       |______|______|______ ______|
+       |      |             |      |
+    3  |  A4  |     B4      |      |
+       |______|______ ______|      |
+       |      |      |      |  D2  |
+    4  |  A5  |  B5  |  C3  |      |
+       |______|______|______|______|
+
+    0: Automatically decide the best place to fit
+        ____________________________
+       |      |             |      |
+    0  |  A2  |     B2      |      |
+       |______|______ ______|      |
+       |      |      |      |  D1  |
+    1  |  A3  |  B3  |  C2  |      |
+       |______|______|______|______|
+       |      |             |      |
+    2  |  A4  |     B4      |      |
+       |______|______ ______|      |
+       |      |      |      |  D2  |
+    3  |  A5  |  B5  |  C3  |      |
+       |______|______|______|______|
+       |      |      |             |
+    4  |  A1  |  B1  |     C1      |
+       |______|______|______ ______|
+
+    1: Always put the origin after the target
+        ____________________________
+       |      |             |      |
+    0  |  A2  |     B2      |      |
+       |______|______ ______|      |
+       |      |      |      |  D1  |
+    1  |  A3  |  B3  |  C2  |      |
+       |______|______|______|______|
+       |      |             |      |
+    2  |  A4  |     B4      |      |
+       |______|______ ______|      |
+       |      |      |      |  D2  |
+    3  |  A5  |  B5  |  C3  |      |
+       |______|______|______|______|
+       |      |      |             |
+    4  |  A1  |  B1  |     C1      |
+       |______|______|______ ______|
+
+   ```javascript
+   dispatch(
+     moveRow(x, y, options)(state.tr)
+   );
+   ```
+
+
+ * **`moveColumn`**`(originColumnIndex: number, targetColumnIndex: targetColumnIndex, options: ?MovementOptions) → fn(tr: Transaction) → Transaction`\
+   Returns a new transaction that moves the origin column to the target index;
+
+   by default "tryToFit" is false, that means if you try to move a column to a place
+   where we will need to split a column with merged cells it'll throw an exception, for example:
+
+      0      1         2
+    ____________________________
+   |      |      |             |
+   |  A1  |  B1  |     C1      |
+   |______|______|______ ______|
+   |      |             |      |
+   |  A2  |     B2      |      |
+   |______|______ ______|      |
+   |      |      |      |  D1  |
+   |  A3  |  B3  |  C2  |      |
+   |______|______|______|______|
+
+
+   if you try to move the column 0 to the column index 1 with tryToFit false,
+   it'll throw an exception since you can't split the column 1;
+   but if "tryToFit" is true, it'll move the column using the current direction.
+
+   We defined current direction using the target and origin values
+   if the origin is greater than the target, that means the course is `right-to-left`,
+   so the `tryToFit` logic will use this direction to determine
+   if we should move the column to the right or the left.
+
+   for example, if you call the function using `moveColumn(0, 1, { tryToFit: true })`
+   the result will be:
+
+      0       1             2
+   _____________________ _______
+   |      |             |      |
+   |  B1  |     C1      |  A1  |
+   |______|______ ______|______|
+   |             |      |      |
+   |     B2      |      |  A2  |
+   |______ ______|      |______|
+   |      |      |  D1  |      |
+   |  B3  |  C2  |      |  A3  |
+   |______|______|______|______|
+
+   since we could put the column zero on index one,
+   we pushed to the best place to fit the column 0, in this case, column index 2.
+
+   -------- HOW TO OVERRIDE DIRECTION --------
+
+   If you set "tryToFit" to "true", it will try to figure out the best direction
+   place to fit using the origin and target index, for example:
+
+
+       0      1       2     3      4      5       6
+     _________________________________________________
+    |      |      |             |      |             |
+    |  A1  |  B1  |     C1      |  E1  |     F1      |
+    |______|______|______ ______|______|______ ______|
+    |      |             |      |             |      |
+    |  A2  |     B2      |      |     E2      |      |
+    |______|______ ______|      |______ ______|      |
+    |      |      |      |  D1  |      |      |  G2  |
+    |  A3  |  B3  |  C3  |      |  E3  |  F3  |      |
+    |______|______|______|______|______|______|______|
+
+
+   If you try to move the column 0 to column index 5 with "tryToFit" enabled, by default,
+   the code will put it on after the merged columns,
+   but you can override it using the "direction" option.
+
+   -1: Always put the origin before the target
+
+       0      1       2     3      4      5       6
+     _________________________________________________
+    |      |             |      |      |             |
+    |  B1  |     C1      |  A1  |  E1  |     F1      |
+    |______|______ ______|______|______|______ ______|
+    |             |      |      |             |      |
+    |     B2      |      |  A2  |     E2      |      |
+    |______ ______|      |______|______ ______|      |
+    |      |      |  D1  |      |      |      |  G2  |
+    |  B3  |  C3  |      |  A3  |  E3  |  F3  |      |
+    |______|______|______|______|______|______|______|
+
+    0: Automatically decide the best place to fit
+
+       0      1       2     3      4      5       6
+     _________________________________________________
+    |      |             |      |             |      |
+    |  B1  |     C1      |  E1  |     F1      |  A1  |
+    |______|______ ______|______|______ ______|______|
+    |             |      |             |      |      |
+    |     B2      |      |     E2      |      |  A2  |
+    |______ ______|      |______ ______|      |______|
+    |      |      |  D1  |      |      |  G2  |      |
+    |  B3  |  C3  |      |  E3  |  F3  |      |  A3  |
+    |______|______|______|______|______|______|______|
+
+    1: Always put the origin after the target
+
+       0      1       2     3      4      5       6
+     _________________________________________________
+    |      |             |      |             |      |
+    |  B1  |     C1      |  E1  |     F1      |  A1  |
+    |______|______ ______|______|______ ______|______|
+    |             |      |             |      |      |
+    |     B2      |      |     E2      |      |  A2  |
+    |______ ______|      |______ ______|      |______|
+    |      |      |  D1  |      |      |  G2  |      |
+    |  B3  |  C3  |      |  E3  |  F3  |      |  A3  |
+    |______|______|______|______|______|______|______|
+
+   ```javascript
+   dispatch(
+     moveColumn(x, y, options)(state.tr)
+   );
+   ```
+
+
  * **`addRowAt`**`(rowIndex: number, clonePreviousRow: ?boolean) → fn(tr: Transaction) → Transaction`\
    Returns a new transaction that adds a new row at index `rowIndex`. Optionally clone the previous row.
 
@@ -623,6 +874,52 @@ npm install prosemirror-utils
      setTextSelection(5)(tr)
    );
    ```
+
+
+ * **`convertTableNodeToArrayOfRows`**`(tableNode: Node) → [Node]`\
+   This function will transform the table node
+   into a matrix of rows and columns respecting merged cells,
+   for example this table will be convert to the below:
+
+    ____________________________
+   |      |      |             |
+   |  A1  |  B1  |     C1      |
+   |______|______|______ ______|
+   |      |             |      |
+   |  A2  |     B2      |      |
+   |______|______ ______|      |
+   |      |      |      |  D1  |
+   |  A3  |  B3  |  C2  |      |
+   |______|______|______|______|
+
+
+   array = [
+     [A1, B1, C1, null],
+     [A2, B2, null, D1],
+     [A3. B3, C2, null],
+   ]
+
+
+ * **`convertArrayOfRowsToTableNode`**`(tableNode: Node, tableArray: [Node]) → Node`\
+   This function will transform a matrix of nodes
+   into table node respecting merged cells and rows configurations,
+   for example this array will be convert to the table below:
+
+   array = [
+     [A1, B1, C1, null],
+     [A2, B2, null, D1],
+     [A3. B3, C2, null],
+   ]
+    ____________________________
+   |      |      |             |
+   |  A1  |  B1  |     C1      |
+   |______|______|______ ______|
+   |      |             |      |
+   |  A2  |     B2      |      |
+   |______|______ ______|      |
+   |      |      |      |  D1  |
+   |  A3  |  B3  |  C2  |      |
+   |______|______|______|______|
 
 
 ## License

--- a/__tests__/helpers.js
+++ b/__tests__/helpers.js
@@ -1,8 +1,31 @@
 import { createEditor, doc, p, strong, atomInline } from '../test-helpers';
 import { Fragment } from 'prosemirror-model';
-import { canInsert, removeNodeAtPos } from '../src/helpers';
+import { canInsert, removeNodeAtPos, transpose } from '../src/helpers';
 
 describe('helpers', () => {
+  describe('transpose', () => {
+    const arr = [
+      ['a1', 'a2', 'a3'],
+      ['b1', 'b2', 'b3'],
+      ['c1', 'c2', 'c3'],
+      ['d1', 'd2', 'd3']
+    ];
+
+    const expected = [
+      ['a1', 'b1', 'c1', 'd1'],
+      ['a2', 'b2', 'c2', 'd2'],
+      ['a3', 'b3', 'c3', 'd3']
+    ];
+
+    it('should invert columns to rows', () => {
+      expect(transpose(arr)).toEqual(expected);
+    });
+
+    it('should guarantee the reflection to be true ', () => {
+      expect(transpose(expected)).toEqual(arr);
+    });
+  });
+
   describe('canInsert', () => {
     it('should return true if insertion of a given node is allowed at the current cursor position', () => {
       const { state } = createEditor(doc(p('one<cursor>')));

--- a/__tests__/table_moveColumn.js
+++ b/__tests__/table_moveColumn.js
@@ -1,0 +1,674 @@
+import {
+  createEditor,
+  doc,
+  p,
+  table,
+  tr as row,
+  td,
+  th,
+  tdCursor,
+  tdEmpty,
+  thEmpty,
+} from '../test-helpers';
+import { moveColumn } from '../src';
+
+describe('table__moveColumn', () => {
+  describe('on a simple table', () => {
+    it('should move column right-to-left', () => {
+      const {
+        state: { tr },
+      } = createEditor(
+        doc(
+          table(
+            row(td(p('1')), tdCursor, tdEmpty),
+            row(td(p('2')), tdEmpty, tdEmpty),
+            row(td(p('3')), tdEmpty, tdEmpty)
+          )
+        )
+      );
+
+      const newTr = moveColumn(2, 0)(tr);
+      expect(newTr.doc).toEqualDocument(
+        doc(
+          table(
+            row(tdEmpty, td(p('1')), tdCursor),
+            row(tdEmpty, td(p('2')), tdEmpty),
+            row(tdEmpty, td(p('3')), tdEmpty)
+          )
+        )
+      );
+    });
+
+    it('should move column left-to-right', () => {
+      const {
+        state: { tr },
+      } = createEditor(
+        doc(
+          table(
+            row(td(p('1')), tdEmpty, tdEmpty),
+            row(td(p('2')), td(p('x')), tdEmpty),
+            row(td(p('3')), tdEmpty, tdEmpty)
+          )
+        )
+      );
+
+      const newTr = moveColumn(1, 2)(tr);
+      expect(newTr.doc).toEqualDocument(
+        doc(
+          table(
+            row(td(p('1')), tdEmpty, tdEmpty),
+            row(td(p('2')), tdEmpty, td(p('x'))),
+            row(td(p('3')), tdEmpty, tdEmpty)
+          )
+        )
+      );
+    });
+  });
+
+  describe('on a table with merged cells', () => {
+    it('should move columns merged at first line', () => {
+      const {
+        state: { tr },
+      } = createEditor(
+        doc(
+          table(
+            row(td(p('1')), td({ colspan: 2 }, p('merged cell'))),
+            row(td(p('2')), tdCursor, tdEmpty),
+            row(td(p('3')), tdEmpty, tdEmpty)
+          )
+        )
+      );
+
+      const newTr = moveColumn(1, 0)(tr);
+      expect(newTr.doc).toEqualDocument(
+        doc(
+          table(
+            row(td({ colspan: 2 }, p('merged cell')), td(p('1'))),
+            row(tdEmpty, tdCursor, td(p('2'))),
+            row(tdEmpty, tdEmpty, td(p('3')))
+          )
+        )
+      );
+    });
+
+    it('should move columns merged at middle line', () => {
+      const {
+        state: { tr },
+      } = createEditor(
+        doc(
+          table(
+            row(td(p('1')), tdCursor, tdEmpty),
+            row(td(p('2')), td({ colspan: 2 }, p('merged cell'))),
+            row(td(p('3')), tdEmpty, tdEmpty)
+          )
+        )
+      );
+
+      const newTr = moveColumn(1, 0)(tr);
+      expect(newTr.doc).toEqualDocument(
+        doc(
+          table(
+            row(tdEmpty, tdCursor, td(p('1'))),
+            row(td({ colspan: 2 }, p('merged cell')), td(p('2'))),
+            row(tdEmpty, tdEmpty, td(p('3')))
+          )
+        )
+      );
+    });
+
+    it('should move columns merged at last line', () => {
+      const {
+        state: { tr },
+      } = createEditor(
+        doc(
+          table(
+            row(td(p('1')), tdCursor, tdEmpty),
+            row(td(p('2')), tdEmpty, tdEmpty),
+            row(td(p('3')), td({ colspan: 2 }, p('merged cell')))
+          )
+        )
+      );
+
+      const newTr = moveColumn(1, 0)(tr);
+      expect(newTr.doc).toEqualDocument(
+        doc(
+          table(
+            row(tdEmpty, tdCursor, td(p('1'))),
+            row(tdEmpty, tdEmpty, td(p('2'))),
+            row(td({ colspan: 2 }, p('merged cell')), td(p('3')))
+          )
+        )
+      );
+    });
+
+    it('should move and keep table headers', () => {
+      const {
+        state: { tr },
+      } = createEditor(
+        doc(
+          table(
+            row(th({ colspan: 2 }, p('merged cell')), thEmpty),
+            row(tdEmpty, tdEmpty, tdEmpty),
+            row(tdEmpty, tdEmpty, tdEmpty)
+          )
+        )
+      );
+
+      const newTr = moveColumn(0, 2)(tr);
+      expect(newTr.doc).toEqualDocument(
+        doc(
+          table(
+            row(thEmpty, th({ colspan: 2 }, p('merged cell'))),
+            row(tdEmpty, tdEmpty, tdEmpty),
+            row(tdEmpty, tdEmpty, tdEmpty)
+          )
+        )
+      );
+    });
+
+    it('should move and keep columns headers', () => {
+      const {
+        state: { tr },
+      } = createEditor(
+        doc(
+          table(
+            row(thEmpty, thEmpty, thEmpty),
+            row(th(p('b1')), tdEmpty, td(p('b2'))),
+            row(thEmpty, tdEmpty, tdEmpty)
+          )
+        )
+      );
+
+      const newTr = moveColumn(2, 0)(tr);
+      expect(newTr.doc).toEqualDocument(
+        doc(
+          table(
+            row(thEmpty, thEmpty, thEmpty),
+            row(th(p('b2')), td(p('b1')), tdEmpty),
+            row(thEmpty, tdEmpty, tdEmpty)
+          )
+        )
+      );
+    });
+  });
+
+  describe('on a table with merged rows', () => {
+    it('should move columns', () => {
+      const {
+        state: { tr },
+      } = createEditor(
+        doc(
+          table(
+            row(
+              td({ rowspan: 2 }, p('---merged-row----')),
+              td(p('a0')),
+              td(p('a1'))
+            ),
+            row(td(p('b1')), td(p('b2'))),
+            row(td(p('c1')), td(p('c2')), td(p('c3')))
+          )
+        )
+      );
+
+      const newTr = moveColumn(1, 2)(tr);
+      expect(newTr.doc).toEqualDocument(
+        doc(
+          table(
+            row(
+              td({ rowspan: 2 }, p('---merged-row----')),
+              td(p('a1')),
+              td(p('a0'))
+            ),
+            row(td(p('b2')), td(p('b1'))),
+            row(td(p('c1')), td(p('c3')), td(p('c2')))
+          )
+        )
+      );
+    });
+
+    it('should move columns for multi rows merged', () => {
+      const {
+        state: { tr },
+      } = createEditor(
+        doc(
+          table(
+            row(td({ rowspan: 2 }, p('a1')), td(p('a1')), td(p('a2'))),
+            row(td(p('b1')), td({ rowspan: 2 }, p('b2'))),
+            row(td(p('c1')), td(p('c2')))
+          )
+        )
+      );
+
+      const newTr = moveColumn(1, 2)(tr);
+      expect(newTr.doc).toEqualDocument(
+        doc(
+          table(
+            row(td({ rowspan: 2 }, p('a1')), td(p('a2')), td(p('a1'))),
+            row(td({ rowspan: 2 }, p('b2')), td(p('b1'))),
+            row(td(p('c1')), td(p('c2')))
+          )
+        )
+      );
+    });
+
+    it('should move columns between two merged rows', () => {
+      const {
+        state: { tr },
+      } = createEditor(
+        doc(
+          table(
+            row(td({ rowspan: 2 }, p('a1')), td(p('a2')), td(p('a3'))),
+            row(td(p('b1')), td({ rowspan: 2 }, p('b2'))),
+            row(td(p('c1')), td(p('c2')))
+          )
+        )
+      );
+
+      const newTr = moveColumn(0, 2)(tr);
+      expect(newTr.doc).toEqualDocument(
+        doc(
+          table(
+            row(td(p('a2')), td(p('a3')), td({ rowspan: 2 }, p('a1'))),
+            row(td(p('b1')), td({ rowspan: 2 }, p('b2'))),
+            row(td(p('c2')), td(p('c1')))
+          )
+        )
+      );
+    });
+  });
+
+  describe('on a complex table with merged cells and rows', () => {
+    it('keep the merged content columns order', () => {
+      const {
+        state: { tr },
+      } = createEditor(
+        doc(
+          table(
+            row(tdEmpty, td(p('a1')), td(p('a2'))),
+            row(tdEmpty, td({ colspan: 2 }, p('b1'))),
+            row(tdEmpty, td(p('c1')), td(p('c2')))
+          )
+        )
+      );
+
+      const newTr = moveColumn(1, 0)(tr);
+      expect(newTr.doc).toEqualDocument(
+        doc(
+          table(
+            row(td(p('a1')), td(p('a2')), tdEmpty),
+            row(td({ colspan: 2 }, p('b1')), tdEmpty),
+            row(td(p('c1')), td(p('c2')), tdEmpty)
+          )
+        )
+      );
+    });
+
+    describe('when the first line all columns are merged', () => {
+      it('should not move columns', () => {
+        const {
+          state: { tr },
+        } = createEditor(
+          doc(
+            table(
+              row(td({ colspan: 3 }, p('a1'))),
+              row(td(p('b1')), tdCursor, tdEmpty),
+              row(td(p('c1')), tdEmpty, tdEmpty)
+            )
+          )
+        );
+
+        const newTr = moveColumn(1, 0)(tr);
+        expect(newTr.doc).toEqualDocument(
+          doc(
+            table(
+              row(td({ colspan: 3 }, p('a1'))),
+              row(td(p('b1')), tdCursor, tdEmpty),
+              row(td(p('c1')), tdEmpty, tdEmpty)
+            )
+          )
+        );
+      });
+    });
+
+    describe('table 3x5', () => {
+      const {
+        state: { tr },
+      } = createEditor(
+        doc(
+          table(
+            row(
+              td({ rowspan: 2 }, p('a0')),
+              td(p('a1')),
+              td(p('a2')),
+              td(p('a3')),
+              td(p('a4'))
+            ),
+            row(
+              td({ colspan: 2 }, p('b1')),
+              td({ rowspan: 2, colspan: 2 }, p('b2'))
+            ),
+            row(td(p('c1')), td(p('c2')), td(p('c3')))
+          )
+        )
+      );
+
+      const expectedResult = doc(
+        table(
+          row(
+            td({ rowspan: 2 }, p('a0')),
+            td(p('a3')),
+            td(p('a4')),
+            td(p('a1')),
+            td(p('a2'))
+          ),
+          row(
+            td({ rowspan: 2, colspan: 2 }, p('b2')),
+            td({ colspan: 2 }, p('b1'))
+          ),
+          row(td(p('c1')), td(p('c2')), td(p('c3')))
+        )
+      );
+
+      describe('with tryToFit false', () => {
+        it('should throw exeception on move column 1 to 3', () => {
+          expect(moveColumn(1, 3, { tryToFit: false }).bind(null, tr)).toThrow(
+            "Target position is invalid, you can't move the column 1 to 3, the target can't be split. You could use tryToFit option."
+          );
+        });
+
+        it('should throw exeception on move column 2 to 3', () => {
+          expect(moveColumn(2, 3, { tryToFit: false }).bind(null, tr)).toThrow(
+            "Target position is invalid, you can't move the column 2 to 3, the target can't be split. You could use tryToFit option."
+          );
+        });
+
+        it('should throw exeception on move column 3 to 2', () => {
+          expect(
+            moveColumn(3, 2, { tryToFit: false }).bind(null, tr)
+          ).toThrow();
+        });
+
+        it('should move column 3 to 1', () => {
+          let newTr = moveColumn(3, 1, { tryToFit: false })(tr);
+          expect(newTr.doc).toEqualDocument(expectedResult);
+        });
+
+        it('should move column 4 to 1', () => {
+          let newTr = moveColumn(4, 1, { tryToFit: false })(tr);
+          expect(newTr.doc).toEqualDocument(expectedResult);
+        });
+      });
+
+      describe('with tryToFit true', () => {
+        it('should move column 1 to 3', () => {
+          let newTr = moveColumn(1, 3, { tryToFit: true })(tr);
+          expect(newTr.doc).toEqualDocument(expectedResult);
+        });
+
+        it('should move column 2 to 3', () => {
+          let newTr = moveColumn(2, 3, { tryToFit: true })(tr);
+          expect(newTr.doc).toEqualDocument(expectedResult);
+        });
+
+        it('should move column 2 to 4', () => {
+          let newTr = moveColumn(2, 4, { tryToFit: true })(tr);
+          expect(newTr.doc).toEqualDocument(expectedResult);
+        });
+
+        it('should move column 3 to 1', () => {
+          let newTr = moveColumn(3, 1, { tryToFit: true })(tr);
+          expect(newTr.doc).toEqualDocument(expectedResult);
+        });
+
+        it('should move column 3 to 2', () => {
+          let newTr = moveColumn(3, 2, { tryToFit: true })(tr);
+          expect(newTr.doc).toEqualDocument(expectedResult);
+        });
+
+        it('should move column 4 to 1', () => {
+          let newTr = moveColumn(4, 1, { tryToFit: true })(tr);
+          expect(newTr.doc).toEqualDocument(expectedResult);
+        });
+
+        it('should move column 4 to 2', () => {
+          let newTr = moveColumn(4, 2, { tryToFit: true })(tr);
+          expect(newTr.doc).toEqualDocument(expectedResult);
+        });
+      });
+    });
+
+    describe('table 3x4', () => {
+      const {
+        state: { tr },
+      } = createEditor(
+        doc(
+          table(
+            row(
+              td({ rowspan: 2 }, p('a1')),
+              td(p('a2')),
+              td(p('a3')),
+              td(p('a4'))
+            ),
+            row(td({ colspan: 2 }, p('b1')), td({ rowspan: 2 }, p('b2'))),
+            row(td(p('c1')), td(p('c2')), td(p('c3')))
+          )
+        )
+      );
+
+      const expectedResult = doc(
+        table(
+          row(
+            td(p('a2')),
+            td(p('a3')),
+            td({ rowspan: 2 }, p('a1')),
+            td(p('a4'))
+          ),
+          row(td({ colspan: 2 }, p('b1')), td({ rowspan: 2 }, p('b2'))),
+          row(td(p('c2')), td(p('c3')), td(p('c1')))
+        )
+      );
+
+      describe('with tryToFit false', () => {
+        it('should throw exeception on move column 0 to 1', () => {
+          expect(
+            moveColumn(0, 1, { tryToFit: false }).bind(null, tr)
+          ).toThrow();
+        });
+
+        it('should move column 0 to 2', () => {
+          let newTr = moveColumn(0, 2, { tryToFit: false })(tr);
+          expect(newTr.doc).toEqualDocument(expectedResult);
+        });
+
+        it('should move column 2 to 0', () => {
+          let newTr = moveColumn(2, 0, { tryToFit: false })(tr);
+          expect(newTr.doc).toEqualDocument(expectedResult);
+        });
+
+        it('should move column 1 to 0', () => {
+          let newTr = moveColumn(1, 0, { tryToFit: false })(tr);
+          expect(newTr.doc).toEqualDocument(expectedResult);
+        });
+      });
+
+      describe('with tryToFit true', () => {
+        it('should move column 0 to 2', () => {
+          let newTr = moveColumn(0, 2, { tryToFit: true })(tr);
+          expect(newTr.doc).toEqualDocument(expectedResult);
+        });
+
+        it('should move column 0 to 1', () => {
+          let newTr = moveColumn(0, 1, { tryToFit: true })(tr);
+          expect(newTr.doc).toEqualDocument(expectedResult);
+        });
+
+        it('should move column 2 to 0', () => {
+          let newTr = moveColumn(2, 0, { tryToFit: true })(tr);
+          expect(newTr.doc).toEqualDocument(expectedResult);
+        });
+
+        it('should move column 1 to 0', () => {
+          let newTr = moveColumn(1, 0, { tryToFit: true })(tr);
+          expect(newTr.doc).toEqualDocument(expectedResult);
+        });
+      });
+    });
+  });
+
+  describe('table 5x3', () => {
+    const {
+      state: { tr },
+    } = createEditor(
+      doc(
+        table(
+          row(th(p('a1')), th(p('a2')), th(p('a3')), th(p('a4')), th(p('a5'))),
+          row(
+            td({ colspan: 2 }, p('b1')),
+            td(p('b2')),
+            td(p('b3')),
+            td(p('b4'))
+          ),
+          row(
+            td(p('c1')),
+            td(p('c2')),
+            td(p('c3')),
+            td({ colspan: 2 }, p('c4'))
+          )
+        )
+      )
+    );
+
+    const expectedResult = doc(
+      table(
+        row(th(p('a3')), th(p('a1')), th(p('a2')), th(p('a4')), th(p('a5'))),
+        row(td(p('b2')), td({ colspan: 2 }, p('b1')), td(p('b3')), td(p('b4'))),
+        row(td(p('c3')), td(p('c1')), td(p('c2')), td({ colspan: 2 }, p('c4')))
+      )
+    );
+
+    it('should move column 2 to 0', () => {
+      let newTr = moveColumn(2, 0)(tr);
+      expect(newTr.doc).toEqualDocument(expectedResult);
+    });
+
+    it('should move column 0 to 2', () => {
+      let newTr = moveColumn(0, 2)(tr);
+      expect(newTr.doc).toEqualDocument(expectedResult);
+    });
+  });
+
+  describe('with tryToFit true', () => {
+    describe('overide the direction when move right-to-left', () => {
+      // Original table
+      //
+      //     0      1       2     3      4      5       6
+      //   _________________________________________________
+      //  |      |             |      |             |      |
+      //  |  A1  |     B1      |  E1  |     F1      |  G1  |
+      //  |______|______ ______|______|______ ______|______|
+      //  |             |      |             |      |      |
+      //  |     A2      |      |     D2      |      |  G2  |
+      //  |______ ______|      |______ ______|      |______|
+      //  |      |      |  C2  |      |      |  F2  |      |
+      //  |  A3  |  B3  |      |  D3  |  E3  |      |  G3  |
+      //  |______|______|______|______|______|______|______|
+      //
+      const {
+        state: { tr },
+      } = createEditor(
+        doc(
+          table(
+            row(
+              td(p('A1')),
+              td({ colspan: 2 }, p('B1')),
+              td(p('E1')),
+              td({ colspan: 2 }, p('F1')),
+              td(p('G1'))
+            ),
+            row(
+              td({ colspan: 2 }, p('A2')),
+              td({ rowspan: 2 }, p('C2')),
+              td({ colspan: 2 }, p('D2')),
+              td({ rowspan: 2 }, p('F2')),
+              td(p('G2'))
+            ),
+            row(td(p('A3')), td(p('B3')), td(p('D3')), td(p('E3')), td(p('G3')))
+          )
+        )
+      );
+
+      // Expected table after move column 6 to position 2 with default direction
+      //
+      //     0      1       2     3      4      5       6
+      //   _________________________________________________
+      //  |      |      |             |      |             |
+      //  |  G1  |  A1  |     B1      |  E1  |     F1      |
+      //  |______|______|______ ______|______|______ ______|
+      //  |      |             |      |             |      |
+      //  |  G2  |     A2      |      |     D2      |      |
+      //  |______|______ ______|      |______ ______|      |
+      //  |      |      |      |  C2  |      |      |  F2  |
+      //  |  G3  |  A3  |  B3  |      |  D3  |  E3  |      |
+      //  |______|______|______|______|______|______|______|
+      //
+      const expectedResultDefaultDirection = doc(
+        table(
+          row(
+            td(p('G1')),
+            td(p('A1')),
+            td({ colspan: 2 }, p('B1')),
+            td(p('E1')),
+            td({ colspan: 2 }, p('F1'))
+          ),
+          row(
+            td(p('G2')),
+            td({ colspan: 2 }, p('A2')),
+            td({ rowspan: 2 }, p('C2')),
+            td({ colspan: 2 }, p('D2')),
+            td({ rowspan: 2 }, p('F2'))
+          ),
+          row(td(p('G3')), td(p('A3')), td(p('B3')), td(p('D3')), td(p('E3')))
+        )
+      );
+
+      // Expected table after move column 6 to position 2 with direction 1
+      //
+      //     0      1       2     3      4      5       6
+      //   _________________________________________________
+      //  |      |             |      |      |             |
+      //  |  A1  |     B1      |  G1  |  E1  |     F1      |
+      //  |______|______ ______|______|______|______ ______|
+      //  |             |      |      |             |      |
+      //  |     A2      |      |  G2  |     D2      |      |
+      //  |______ ______|      |______|______ ______|      |
+      //  |      |      |  C2  |      |      |      |  F2  |
+      //  |  A3  |  B3  |      |  G3  |  D3  |  E3  |      |
+      //  |______|______|______|______|______|______|______|
+      //
+      const expectedResultMinusOneDirection = doc(
+        table(
+          row(
+            td(p('A1')),
+            td({ colspan: 2 }, p('B1')),
+            td(p('G1')),
+            td(p('E1')),
+            td({ colspan: 2 }, p('F1'))
+          ),
+          row(
+            td({ colspan: 2 }, p('A2')),
+            td({ rowspan: 2 }, p('C2')),
+            td(p('G2')),
+            td({ colspan: 2 }, p('D2')),
+            td({ rowspan: 2 }, p('F2'))
+          ),
+          row(td(p('A3')), td(p('B3')), td(p('G3')), td(p('D3')), td(p('E3')))
+        )
+      );
+
+      it('should move row 6 to position 2 with direction 1', () => {
+        let newTr = moveColumn(6, 2, { tryToFit: true, direction: 1 })(tr);
+        expect(newTr.doc).toEqualDocument(expectedResultMinusOneDirection);
+      });
+    });
+  });
+});

--- a/__tests__/table_moveRow.js
+++ b/__tests__/table_moveRow.js
@@ -1,0 +1,884 @@
+import {
+  createEditor,
+  doc,
+  p,
+  table,
+  tr as row,
+  td,
+  th,
+  tdCursor,
+  tdEmpty,
+  thEmpty,
+} from '../test-helpers';
+import { moveRow } from '../src';
+
+describe('table__moveRow', () => {
+  describe('on a simple table', () => {
+    it('should move row bottom-to-top', () => {
+      const {
+        state: { tr },
+      } = createEditor(
+        doc(
+          table(
+            row(td(p('1')), tdCursor, tdEmpty),
+            row(td(p('2')), tdEmpty, tdEmpty),
+            row(td(p('3')), tdEmpty, tdEmpty)
+          )
+        )
+      );
+
+      const newTr = moveRow(2, 0)(tr);
+      expect(newTr.doc).toEqualDocument(
+        doc(
+          table(
+            row(td(p('3')), tdEmpty, tdEmpty),
+            row(td(p('1')), tdCursor, tdEmpty),
+            row(td(p('2')), tdEmpty, tdEmpty)
+          )
+        )
+      );
+    });
+
+    it('should move row top-to-bottom', () => {
+      const {
+        state: { tr },
+      } = createEditor(
+        doc(
+          table(
+            row(td(p('1')), tdEmpty, tdEmpty),
+            row(td(p('2')), td(p('x')), tdEmpty),
+            row(td(p('3')), tdEmpty, tdEmpty)
+          )
+        )
+      );
+
+      const newTr = moveRow(1, 2)(tr);
+      expect(newTr.doc).toEqualDocument(
+        doc(
+          table(
+            row(td(p('1')), tdEmpty, tdEmpty),
+            row(td(p('3')), tdEmpty, tdEmpty),
+            row(td(p('2')), td(p('x')), tdEmpty)
+          )
+        )
+      );
+    });
+  });
+
+  describe('on a table with merged cells', () => {
+    it('should move columns merged at first line', () => {
+      const {
+        state: { tr },
+      } = createEditor(
+        doc(
+          table(
+            row(td(p('1')), td({ colspan: 2 }, p('merged cell'))),
+            row(td(p('2')), tdCursor, tdEmpty),
+            row(td(p('3')), tdEmpty, tdEmpty)
+          )
+        )
+      );
+
+      const newTr = moveRow(1, 0)(tr);
+      expect(newTr.doc).toEqualDocument(
+        doc(
+          table(
+            row(td(p('2')), tdCursor, tdEmpty),
+            row(td(p('1')), td({ colspan: 2 }, p('merged cell'))),
+            row(td(p('3')), tdEmpty, tdEmpty)
+          )
+        )
+      );
+    });
+
+    it('should move columns merged at middle line', () => {
+      const {
+        state: { tr },
+      } = createEditor(
+        doc(
+          table(
+            row(td(p('1')), tdCursor, tdEmpty),
+            row(td(p('2')), td({ colspan: 2 }, p('merged cell'))),
+            row(td(p('3')), tdEmpty, tdEmpty)
+          )
+        )
+      );
+
+      const newTr = moveRow(1, 0)(tr);
+      expect(newTr.doc).toEqualDocument(
+        doc(
+          table(
+            row(td(p('2')), td({ colspan: 2 }, p('merged cell'))),
+            row(td(p('1')), tdCursor, tdEmpty),
+            row(td(p('3')), tdEmpty, tdEmpty)
+          )
+        )
+      );
+    });
+
+    it('should move lines with columns merged at last line', () => {
+      const {
+        state: { tr },
+      } = createEditor(
+        doc(
+          table(
+            row(td(p('1')), tdCursor, tdEmpty),
+            row(td(p('2')), tdEmpty, tdEmpty),
+            row(td(p('3')), td({ colspan: 2 }, p('merged cell')))
+          )
+        )
+      );
+
+      const newTr = moveRow(1, 0)(tr);
+      expect(newTr.doc).toEqualDocument(
+        doc(
+          table(
+            row(td(p('2')), tdEmpty, tdEmpty),
+            row(td(p('1')), tdCursor, tdEmpty),
+            row(td(p('3')), td({ colspan: 2 }, p('merged cell')))
+          )
+        )
+      );
+    });
+
+    it('should move and keep table headers', () => {
+      const {
+        state: { tr },
+      } = createEditor(
+        doc(
+          table(
+            row(th({ colspan: 2 }, p('merged cell')), thEmpty),
+            row(tdEmpty, tdEmpty, tdEmpty),
+            row(tdEmpty, tdEmpty, tdEmpty)
+          )
+        )
+      );
+
+      const newTr = moveRow(0, 2)(tr);
+      expect(newTr.doc).toEqualDocument(
+        doc(
+          table(
+            row(thEmpty, thEmpty, thEmpty),
+            row(tdEmpty, tdEmpty, tdEmpty),
+            row(td({ colspan: 2 }, p('merged cell')), tdEmpty)
+          )
+        )
+      );
+    });
+  });
+
+  describe('on a table with merged rows', () => {
+    it('should move rows', () => {
+      const {
+        state: { tr },
+      } = createEditor(
+        doc(
+          table(
+            row(
+              td({ rowspan: 2 }, p('---merged-row----')),
+              td(p('0')),
+              td(p('1'))
+            ),
+            row(td(p('2')), td(p('3'))),
+            row(td(p('4')), td(p('5')), td(p('6')))
+          )
+        )
+      );
+
+      const newTr = moveRow(1, 2)(tr);
+      expect(newTr.doc).toEqualDocument(
+        doc(
+          table(
+            row(td(p('4')), td(p('5')), td(p('6'))),
+            row(
+              td({ rowspan: 2 }, p('---merged-row----')),
+              td(p('0')),
+              td(p('1'))
+            ),
+            row(td(p('2')), td(p('3')))
+          )
+        )
+      );
+    });
+
+    describe('when there is multi rows merged', () => {
+      it('should not move rows when there is no space to move', () => {
+        const docOriginal = doc(
+          table(
+            row(
+              td({ rowspan: 2 }, p('---merged-row----')),
+              td(p('0')),
+              td(p('1'))
+            ),
+            row(td(p('2')), td({ rowspan: 2 }, p('---merged-row----'))),
+            row(td(p('4')), td(p('5')))
+          )
+        );
+        const {
+          state: { tr },
+        } = createEditor(docOriginal);
+
+        const newTr = moveRow(1, 2)(tr);
+        expect(newTr.doc).toEqualDocument(docOriginal);
+      });
+    });
+
+    it('should not move rows between two merged rows', () => {
+      const {
+        state: { tr },
+      } = createEditor(
+        doc(
+          table(
+            row(
+              td({ rowspan: 2 }, p('---merged-row----')),
+              td(p('0')),
+              td(p('1'))
+            ),
+            row(td(p('2')), td({ rowspan: 2 }, p('---merged-row----'))),
+            row(td(p('4')), td(p('5')))
+          )
+        )
+      );
+
+      const newTr = moveRow(0, 2)(tr);
+      expect(newTr.doc).toEqualDocument(
+        doc(
+          table(
+            row(
+              td({ rowspan: 2 }, p('---merged-row----')),
+              td(p('0')),
+              td(p('1'))
+            ),
+            row(td(p('2')), td({ rowspan: 2 }, p('---merged-row----'))),
+            row(td(p('4')), td(p('5')))
+          )
+        )
+      );
+    });
+  });
+
+  describe('on a complex table with merged columns and rows', () => {
+    it('keep the merged content columns order', () => {
+      const {
+        state: { tr },
+      } = createEditor(
+        doc(
+          table(
+            row(tdEmpty, td(p('1')), td(p('2'))),
+            row(tdEmpty, td({ colspan: 2 }, p('3'))),
+            row(tdEmpty, td(p('4')), td(p('5')))
+          )
+        )
+      );
+
+      const newTr = moveRow(1, 0)(tr);
+      expect(newTr.doc).toEqualDocument(
+        doc(
+          table(
+            row(tdEmpty, td({ colspan: 2 }, p('3'))),
+            row(tdEmpty, td(p('1')), td(p('2'))),
+            row(tdEmpty, td(p('4')), td(p('5')))
+          )
+        )
+      );
+    });
+
+    describe('when the all cells from first column are merged ', () => {
+      it('should not move rows', () => {
+        const {
+          state: { tr },
+        } = createEditor(
+          doc(
+            table(
+              row(td({ rowspan: 3 }, p('merged cell'))),
+              row(td(p('2')), tdCursor, tdEmpty),
+              row(td(p('3')), tdEmpty, tdEmpty)
+            )
+          )
+        );
+
+        const newTr = moveRow(1, 0)(tr);
+        expect(newTr.doc).toEqualDocument(
+          doc(
+            table(
+              row(td({ rowspan: 3 }, p('merged cell'))),
+              row(td(p('2')), tdCursor, tdEmpty),
+              row(td(p('3')), tdEmpty, tdEmpty)
+            )
+          )
+        );
+      });
+    });
+
+    describe('table 3x5', () => {
+      describe('should move', () => {
+        const {
+          state: { tr },
+        } = createEditor(
+          doc(
+            table(
+              row(
+                td({ rowspan: 2 }, p('a1')),
+                td(p('a1')),
+                td(p('a2')),
+                td(p('a3')),
+                td(p('a4'))
+              ),
+              row(td({ colspan: 4 }, p('b1'))),
+              row(
+                td(p('c1')),
+                td(p('c2')),
+                td({ colspan: 2 }, p('c3')),
+                td(p('c4'))
+              )
+            )
+          )
+        );
+        const expectedResult = doc(
+          table(
+            row(
+              td(p('c1')),
+              td(p('c2')),
+              td({ colspan: 2 }, p('c3')),
+              td(p('c4'))
+            ),
+            row(
+              td({ rowspan: 2 }, p('a1')),
+              td(p('a1')),
+              td(p('a2')),
+              td(p('a3')),
+              td(p('a4'))
+            ),
+            row(td({ colspan: 4 }, p('b1')))
+          )
+        );
+
+        it('row 0 to 2', () => {
+          let newTr = moveRow(0, 2)(tr);
+          expect(newTr.doc).toEqualDocument(expectedResult);
+        });
+
+        it('row 1 to 2', () => {
+          let newTr = moveRow(1, 2)(tr);
+          expect(newTr.doc).toEqualDocument(expectedResult);
+        });
+
+        it('row 2 to 0', () => {
+          let newTr = moveRow(2, 0)(tr);
+          expect(newTr.doc).toEqualDocument(expectedResult);
+        });
+
+        describe('with tryToFit true', () => {
+          it('row 2 to 1', () => {
+            let newTr = moveRow(2, 1, { tryToFit: true })(tr);
+            expect(newTr.doc).toEqualDocument(expectedResult);
+          });
+        });
+
+        describe('with tryToFit false', () => {
+          it('throw exeception on move row 2 to 1', () => {
+            expect(moveRow(2, 1, { tryToFit: false }).bind(null, tr)).toThrow();
+          });
+        });
+      });
+
+      describe('should not move', () => {
+        const {
+          state: { tr },
+        } = createEditor(
+          doc(
+            table(
+              row(
+                td({ rowspan: 2 }, p('M1')),
+                td(p('0')),
+                td(p('1')),
+                td(p('2')),
+                td(p('3'))
+              ),
+              row(
+                td({ colspan: 2 }, p('4')),
+                td({ rowspan: 2, colspan: 2 }, p('M2'))
+              ),
+              row(td(p('5')), td(p('6')), td(p('7')))
+            )
+          )
+        );
+
+        const expectedResult = doc(
+          table(
+            row(
+              td({ rowspan: 2 }, p('M1')),
+              td(p('0')),
+              td(p('1')),
+              td(p('2')),
+              td(p('3'))
+            ),
+            row(
+              td({ colspan: 2 }, p('4')),
+              td({ rowspan: 2, colspan: 2 }, p('M2'))
+            ),
+            row(td(p('5')), td(p('6')), td(p('7')))
+          )
+        );
+
+        it('row 0 to 1', () => {
+          let newTr = moveRow(0, 1)(tr);
+          expect(newTr.doc).toEqualDocument(expectedResult);
+        });
+
+        it('row 0 to 2', () => {
+          let newTr = moveRow(0, 2)(tr);
+          expect(newTr.doc).toEqualDocument(expectedResult);
+        });
+
+        it('row 1 to 0', () => {
+          let newTr = moveRow(1, 0)(tr);
+          expect(newTr.doc).toEqualDocument(expectedResult);
+        });
+
+        it('row 1 to 1', () => {
+          let newTr = moveRow(1, 1)(tr);
+          expect(newTr.doc).toEqualDocument(expectedResult);
+        });
+
+        it('row 1 to 2', () => {
+          let newTr = moveRow(1, 2)(tr);
+          expect(newTr.doc).toEqualDocument(expectedResult);
+        });
+
+        it('row 2 to 0', () => {
+          let newTr = moveRow(2, 0)(tr);
+          expect(newTr.doc).toEqualDocument(expectedResult);
+        });
+
+        it('row 2 to 1', () => {
+          let newTr = moveRow(2, 1)(tr);
+          expect(newTr.doc).toEqualDocument(expectedResult);
+        });
+
+        it('row 2 to 2', () => {
+          let newTr = moveRow(2, 2)(tr);
+          expect(newTr.doc).toEqualDocument(expectedResult);
+        });
+      });
+    });
+
+    describe('table 3x4', () => {
+      describe('should move', () => {
+        const {
+          state: { tr },
+        } = createEditor(
+          doc(
+            table(
+              row(
+                td({ rowspan: 2 }, p('M1')),
+                td(p('0')),
+                td(p('1')),
+                td(p('2'))
+              ),
+              row(td({ colspan: 2 }, p('3')), td(p('m2'))),
+              row(td({ colspan: 4 }, p('4')))
+            )
+          )
+        );
+
+        const expectedResult = doc(
+          table(
+            row(td({ colspan: 4 }, p('4'))),
+            row(
+              td({ rowspan: 2 }, p('M1')),
+              td(p('0')),
+              td(p('1')),
+              td(p('2'))
+            ),
+            row(td({ colspan: 2 }, p('3')), td(p('m2')))
+          )
+        );
+
+        it('row 0 to 2', () => {
+          let newTr = moveRow(0, 2)(tr);
+          expect(newTr.doc).toEqualDocument(expectedResult);
+        });
+
+        it('row 1 to 2', () => {
+          let newTr = moveRow(1, 2)(tr);
+          expect(newTr.doc).toEqualDocument(expectedResult);
+        });
+
+        it('row 2 to 0', () => {
+          let newTr = moveRow(2, 0)(tr);
+          expect(newTr.doc).toEqualDocument(expectedResult);
+        });
+
+        describe('with tryToFit true', () => {
+          it('row 2 to 1', () => {
+            let newTr = moveRow(2, 1, { tryToFit: true })(tr);
+            expect(newTr.doc).toEqualDocument(expectedResult);
+          });
+        });
+
+        describe('with tryToFit false', () => {
+          it('throw exeception on move row 2 to 1', () => {
+            expect(moveRow(2, 1, { tryToFit: false }).bind(null, tr)).toThrow();
+          });
+        });
+      });
+
+      describe('should not move', () => {
+        const {
+          state: { tr },
+        } = createEditor(
+          doc(
+            table(
+              row(
+                td({ rowspan: 2 }, p('M1')),
+                td(p('0')),
+                td(p('1')),
+                td(p('2'))
+              ),
+              row(td({ colspan: 2 }, p('3')), td({ rowspan: 2 }, p('m2'))),
+              row(td(p('4')), td(p('5')), td(p('6')))
+            )
+          )
+        );
+
+        const expectedResult = doc(
+          table(
+            row(
+              td({ rowspan: 2 }, p('M1')),
+              td(p('0')),
+              td(p('1')),
+              td(p('2'))
+            ),
+            row(td({ colspan: 2 }, p('3')), td({ rowspan: 2 }, p('m2'))),
+            row(td(p('4')), td(p('5')), td(p('6')))
+          )
+        );
+
+        it('row 0 to 2', () => {
+          let newTr = moveRow(0, 2)(tr);
+          expect(newTr.doc).toEqualDocument(expectedResult);
+        });
+
+        it('row 0 to 1', () => {
+          let newTr = moveRow(0, 1)(tr);
+          expect(newTr.doc).toEqualDocument(expectedResult);
+        });
+
+        it('row 2 to 0', () => {
+          let newTr = moveRow(2, 0)(tr);
+          expect(newTr.doc).toEqualDocument(expectedResult);
+        });
+
+        it('row 1 to 0', () => {
+          let newTr = moveRow(1, 0)(tr);
+          expect(newTr.doc).toEqualDocument(expectedResult);
+        });
+      });
+    });
+  });
+
+  describe('table 5x3 and move cell type', () => {
+    const {
+      state: { tr },
+    } = createEditor(
+      doc(
+        table(
+          row(th(p('1')), th(p('2')), th(p('===')), th(p('a')), th(p('b'))),
+          row(td({ colspan: 2 }, p('3')), td(p('===')), td(p('c')), td(p('d'))),
+          row(td(p('4')), td(p('5')), td(p('===')), td({ colspan: 2 }, p('E')))
+        )
+      )
+    );
+
+    it('should move row 2 to 0', () => {
+      let newTr = moveRow(2, 0)(tr);
+      const expectedResult = doc(
+        table(
+          row(th(p('4')), th(p('5')), th(p('===')), th({ colspan: 2 }, p('E'))),
+          row(td(p('1')), td(p('2')), td(p('===')), td(p('a')), td(p('b'))),
+          row(td({ colspan: 2 }, p('3')), td(p('===')), td(p('c')), td(p('d')))
+        )
+      );
+
+      expect(newTr.doc).toEqualDocument(expectedResult);
+    });
+
+    it('should move row 0 to 2 and', () => {
+      let newTr = moveRow(0, 2)(tr);
+      const expectedResult = doc(
+        table(
+          row(th({ colspan: 2 }, p('3')), th(p('===')), th(p('c')), th(p('d'))),
+          row(td(p('4')), td(p('5')), td(p('===')), td({ colspan: 2 }, p('E'))),
+          row(td(p('1')), td(p('2')), td(p('===')), td(p('a')), td(p('b')))
+        )
+      );
+
+      expect(newTr.doc).toEqualDocument(expectedResult);
+    });
+  });
+
+  describe('with tryToFit true', () => {
+    describe('overide the direction when move bottom-to-top', () => {
+      // Original table
+      //      ____________________________
+      //     |      |             |      |
+      //  0  |  A1  |     B1      |      |
+      //     |______|______ ______|      |
+      //     |      |      |      |  D1  |
+      //  1  |  A2  |  B2  |  C2  |      |
+      //     |______|______|______|______|
+      //     |      |             |      |
+      //  2  |  A3  |     B3      |      |
+      //     |______|______ ______|      |
+      //     |      |      |      |  D3  |
+      //  3  |  A4  |  B4  |  C4  |      |
+      //     |______|______|______|______|
+      //     |      |      |             |
+      //  4  |  A5  |  B5  |     C5      |
+      //     |______|______|______ ______|
+      const {
+        state: { tr },
+      } = createEditor(
+        doc(
+          table(
+            row(
+              td(p('A1')),
+              td({ colspan: 2 }, p('B1')),
+              td({ rowspan: 2 }, p('D1'))
+            ),
+            row(td(p('A2')), td(p('B2')), td(p('C2'))),
+            row(
+              td(p('A3')),
+              td({ colspan: 2 }, p('B3')),
+              td({ rowspan: 2 }, p('D3'))
+            ),
+            row(td(p('A4')), td(p('B4')), td(p('C4'))),
+            row(td(p('A5')), td(p('B5')), td({ colspan: 2 }, p('C5')))
+          )
+        )
+      );
+
+      // Expected table after move row 4 to position 1 with default direction
+      //      ____________________________
+      //     |      |      |             |
+      //  0  |  A5  |  B5  |     C5      |
+      //     |______|______|______ ______|
+      //     |      |             |      |
+      //  1  |  A1  |     B1      |      |
+      //     |______|______ ______|      |
+      //     |      |      |      |  D1  |
+      //  2  |  A2  |  B2  |  C2  |      |
+      //     |______|______|______|______|
+      //     |      |             |      |
+      //  3  |  A3  |     B3      |      |
+      //     |______|______ ______|      |
+      //     |      |      |      |  D3  |
+      //  4  |  A4  |  B4  |  C4  |      |
+      //     |______|______|______|______|
+      const expectedResultDefaultDirection = doc(
+        table(
+          row(td(p('A5')), td(p('B5')), td({ colspan: 2 }, p('C5'))),
+          row(
+            td(p('A1')),
+            td({ colspan: 2 }, p('B1')),
+            td({ rowspan: 2 }, p('D1'))
+          ),
+          row(td(p('A2')), td(p('B2')), td(p('C2'))),
+          row(
+            td(p('A3')),
+            td({ colspan: 2 }, p('B3')),
+            td({ rowspan: 2 }, p('D3'))
+          ),
+          row(td(p('A4')), td(p('B4')), td(p('C4')))
+        )
+      );
+
+      // Expected table after move row 4 to position 1 with direction one
+      //      ____________________________
+      //     |      |             |      |
+      //  0  |  A1  |     B1      |      |
+      //     |______|______ ______|      |
+      //     |      |      |      |  D1  |
+      //  1  |  A2  |  B2  |  C2  |      |
+      //     |______|______|______|______|
+      //     |      |      |             |
+      //  2  |  A5  |  B5  |     C5      |
+      //     |______|______|______ ______|
+      //     |      |             |      |
+      //  3  |  A3  |     B3      |      |
+      //     |______|______ ______|      |
+      //     |      |      |      |  D3  |
+      //  4  |  A4  |  B4  |  C4  |      |
+      //     |______|______|______|______|
+      const expectedResultDirectionOne = doc(
+        table(
+          row(
+            td(p('A1')),
+            td({ colspan: 2 }, p('B1')),
+            td({ rowspan: 2 }, p('D1'))
+          ),
+          row(td(p('A2')), td(p('B2')), td(p('C2'))),
+          row(td(p('A5')), td(p('B5')), td({ colspan: 2 }, p('C5'))),
+          row(
+            td(p('A3')),
+            td({ colspan: 2 }, p('B3')),
+            td({ rowspan: 2 }, p('D3'))
+          ),
+          row(td(p('A4')), td(p('B4')), td(p('C4')))
+        )
+      );
+
+      it('should move row 4 to position 1 with default direction', () => {
+        let newTr = moveRow(4, 1, { tryToFit: true })(tr);
+        expect(newTr.doc).toEqualDocument(expectedResultDefaultDirection);
+      });
+
+      it('should move row 4 to position 1 with direction zero', () => {
+        let newTr = moveRow(4, 1, { tryToFit: true, direction: 0 })(tr);
+        expect(newTr.doc).toEqualDocument(expectedResultDefaultDirection);
+      });
+
+      it('should move row 4 to position 1 with direction -1', () => {
+        let newTr = moveRow(4, 1, { tryToFit: true, direction: -1 })(tr);
+        expect(newTr.doc).toEqualDocument(expectedResultDefaultDirection);
+      });
+
+      it('should move row 4 to position 1 with direction 1', () => {
+        let newTr = moveRow(4, 1, { tryToFit: true, direction: 1 })(tr);
+        expect(newTr.doc).toEqualDocument(expectedResultDirectionOne);
+      });
+    });
+
+    describe('overide the direction when move top-to-bottom', () => {
+      // Original table
+      //      ____________________________
+      //     |      |      |             |
+      //  0  |  A1  |  B1  |     C1      |
+      //     |______|______|______ ______|
+      //     |      |             |      |
+      //  1  |  A2  |     B2      |      |
+      //     |______|______ ______|      |
+      //     |      |      |      |  D2  |
+      //  2  |  A3  |  B3  |  C3  |      |
+      //     |______|______|______|______|
+      //     |      |             |      |
+      //  3  |  A4  |     B4      |      |
+      //     |______|______ ______|      |
+      //     |      |      |      |  D4  |
+      //  4  |  A5  |  B5  |  C5  |      |
+      //     |______|______|______|______|
+      const {
+        state: { tr },
+      } = createEditor(
+        doc(
+          table(
+            row(td(p('A1')), td(p('B1')), td({ colspan: 2 }, p('C1'))),
+            row(
+              td(p('A2')),
+              td({ colspan: 2 }, p('B2')),
+              td({ rowspan: 2 }, p('D2'))
+            ),
+            row(td(p('A3')), td(p('B3')), td(p('C3'))),
+            row(
+              td(p('A4')),
+              td({ colspan: 2 }, p('B4')),
+              td({ rowspan: 2 }, p('D4'))
+            ),
+            row(td(p('A5')), td(p('B5')), td(p('C5')))
+          )
+        )
+      );
+
+      // Expected table after move row 0 to position 4 with default direction
+      //      ____________________________
+      //     |      |             |      |
+      //  0  |  A2  |     B2      |      |
+      //     |______|______ ______|      |
+      //     |      |      |      |  D2  |
+      //  1  |  A3  |  B3  |  C3  |      |
+      //     |______|______|______|______|
+      //     |      |             |      |
+      //  2  |  A4  |     B4      |      |
+      //     |______|______ ______|      |
+      //     |      |      |      |  D4  |
+      //  3  |  A5  |  B5  |  C5  |      |
+      //     |______|______|______|______|
+      //     |      |      |             |
+      //  4  |  A1  |  B1  |     C1      |
+      //     |______|______|______ ______|
+      const expectedResultDefaultDirection = doc(
+        table(
+          row(
+            td(p('A2')),
+            td({ colspan: 2 }, p('B2')),
+            td({ rowspan: 2 }, p('D2'))
+          ),
+          row(td(p('A3')), td(p('B3')), td(p('C3'))),
+          row(
+            td(p('A4')),
+            td({ colspan: 2 }, p('B4')),
+            td({ rowspan: 2 }, p('D4'))
+          ),
+          row(td(p('A5')), td(p('B5')), td(p('C5'))),
+          row(td(p('A1')), td(p('B1')), td({ colspan: 2 }, p('C1')))
+        )
+      );
+
+      // Expected table after move row 0 to position 4 with -1 direction
+      //      ____________________________
+      //     |      |             |      |
+      //  0  |  A2  |     B2      |      |
+      //     |______|______ ______|      |
+      //     |      |      |      |  D2  |
+      //  1  |  A3  |  B3  |  C3  |      |
+      //     |______|______|______|______|
+      //     |      |      |             |
+      //  2  |  A1  |  B1  |     C1      |
+      //     |______|______|______ ______|
+      //     |      |             |      |
+      //  3  |  A4  |     B4      |      |
+      //     |______|______ ______|      |
+      //     |      |      |      |  D4  |
+      //  4  |  A5  |  B5  |  C5  |      |
+      //     |______|______|______|______|
+      const expectedResultDirectionMinusOne = doc(
+        table(
+          row(
+            td(p('A2')),
+            td({ colspan: 2 }, p('B2')),
+            td({ rowspan: 2 }, p('D2'))
+          ),
+          row(td(p('A3')), td(p('B3')), td(p('C3'))),
+          row(td(p('A1')), td(p('B1')), td({ colspan: 2 }, p('C1'))),
+          row(
+            td(p('A4')),
+            td({ colspan: 2 }, p('B4')),
+            td({ rowspan: 2 }, p('D4'))
+          ),
+          row(td(p('A5')), td(p('B5')), td(p('C5')))
+        )
+      );
+
+      it('should move row 0 to position 4 with default direction', () => {
+        let newTr = moveRow(0, 4, { tryToFit: true })(tr);
+        expect(newTr.doc).toEqualDocument(expectedResultDefaultDirection);
+      });
+
+      it('should move row 0 to position 4 with direction 0', () => {
+        let newTr = moveRow(0, 4, { tryToFit: true, direction: 0 })(tr);
+        expect(newTr.doc).toEqualDocument(expectedResultDefaultDirection);
+      });
+
+      it('should move row 0 to position 4 with direction 1', () => {
+        let newTr = moveRow(0, 4, { tryToFit: true, direction: 1 })(tr);
+        expect(newTr.doc).toEqualDocument(expectedResultDefaultDirection);
+      });
+
+      it('should move row 0 to position 4 with direction -1', () => {
+        let newTr = moveRow(0, 4, { tryToFit: true, direction: -1 })(tr);
+        expect(newTr.doc).toEqualDocument(expectedResultDirectionMinusOne);
+      });
+    });
+  });
+});

--- a/src/README.md
+++ b/src/README.md
@@ -92,6 +92,10 @@ npm install prosemirror-utils
 
 @addColumnAt
 
+@moveRow
+
+@moveColumn
+
 @addRowAt
 
 @cloneRowAt
@@ -149,6 +153,10 @@ npm install prosemirror-utils
 @removeNodeBefore
 
 @setTextSelection
+
+@convertTableNodeToArrayOfRows
+
+@convertArrayOfRowsToTableNode
 
 ## License
 

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -155,3 +155,211 @@ export const isRectSelected = rect => selection => {
 
   return true;
 };
+
+// This function transposes an array of array flipping the columns for rows,
+// transposition is a familiar algebra concept;
+// you can get more details here:
+// https://en.wikipedia.org/wiki/Transpose
+//
+// ```javascript
+//
+//  const arr = [
+//    ['a1', 'a2', 'a3'],
+//    ['b1', 'b2', 'b3'],
+//    ['c1', 'c2', 'c3'],
+//    ['d1', 'd2', 'd3'],
+//  ];
+//
+//  const result = transpose(arr);
+//
+//  result === [
+//    ['a1', 'b1', 'c1', 'd1'],
+//    ['a2', 'b2', 'c2', 'd2'],
+//    ['a3', 'b3', 'c3', 'd3'],
+//  ]
+// ```
+export const transpose = array => {
+  return array[0].map((_, i) => {
+    return array.map(column => column[i]);
+  });
+};
+
+// :: (tableNode: Node) -> Array<Node>
+// This function will transform the table node
+// into a matrix of rows and columns respecting merged cells,
+// for example this table will be convert to the below:
+//
+//  ____________________________
+// |      |      |             |
+// |  A1  |  B1  |     C1      |
+// |______|______|______ ______|
+// |      |             |      |
+// |  A2  |     B2      |      |
+// |______|______ ______|      |
+// |      |      |      |  D1  |
+// |  A3  |  B3  |  C2  |      |
+// |______|______|______|______|
+//
+//
+// array = [
+//   [A1, B1, C1, null],
+//   [A2, B2, null, D1],
+//   [A3. B3, C2, null],
+// ]
+export const convertTableNodeToArrayOfRows = tableNode => {
+  const map = TableMap.get(tableNode);
+  const rows = [];
+  for (let rowIndex = 0; rowIndex < map.height; rowIndex++) {
+    const rowCells = [];
+    const seen = {};
+
+    for (let colIndex = 0; colIndex < map.width; colIndex++) {
+      const cellPos = map.map[rowIndex * map.width + colIndex];
+      const cell = tableNode.nodeAt(cellPos);
+      const rect = map.findCell(cellPos);
+      if (seen[cellPos] || rect.top !== rowIndex) {
+        rowCells.push(null);
+        continue;
+      }
+      seen[cellPos] = true;
+
+      rowCells.push(cell);
+    }
+
+    rows.push(rowCells);
+  }
+
+  return rows;
+};
+
+// :: (tableNode: Node, tableArray: Array<Node>) -> Node
+// This function will transform a matrix of nodes
+// into table node respecting merged cells and rows configurations,
+// for example this array will be convert to the table below:
+//
+// array = [
+//   [A1, B1, C1, null],
+//   [A2, B2, null, D1],
+//   [A3. B3, C2, null],
+// ]
+//  ____________________________
+// |      |      |             |
+// |  A1  |  B1  |     C1      |
+// |______|______|______ ______|
+// |      |             |      |
+// |  A2  |     B2      |      |
+// |______|______ ______|      |
+// |      |      |      |  D1  |
+// |  A3  |  B3  |  C2  |      |
+// |______|______|______|______|
+//
+export const convertArrayOfRowsToTableNode = (tableNode, arrayOfNodes) => {
+  const rowsPM = [];
+  const map = TableMap.get(tableNode);
+  for (let rowIndex = 0; rowIndex < map.height; rowIndex++) {
+    const row = tableNode.child(rowIndex);
+    const rowCells = [];
+
+    for (let colIndex = 0; colIndex < map.width; colIndex++) {
+      if (!arrayOfNodes[rowIndex][colIndex]) {
+        continue;
+      }
+      const cellPos = map.map[rowIndex * map.width + colIndex];
+
+      const cell = arrayOfNodes[rowIndex][colIndex];
+      const oldCell = tableNode.nodeAt(cellPos);
+      const newCell = oldCell.type.createChecked(
+        Object.assign({}, cell.attrs),
+        cell.content,
+        cell.marks
+      );
+      rowCells.push(newCell);
+    }
+
+    rowsPM.push(row.type.createChecked(row.attrs, rowCells, row.marks));
+  }
+
+  const newTable = tableNode.type.createChecked(
+    tableNode.attrs,
+    rowsPM,
+    tableNode.marks
+  );
+
+  return newTable;
+};
+
+export const moveTableColumn = (
+  table,
+  indexesOrigin,
+  indexesTarget,
+  direction
+) => {
+  let rows = transpose(convertTableNodeToArrayOfRows(table.node));
+
+  rows = moveRowInArrayOfRows(rows, indexesOrigin, indexesTarget, direction);
+  rows = transpose(rows);
+
+  return convertArrayOfRowsToTableNode(table.node, rows);
+};
+
+export const moveTableRow = (
+  table,
+  indexesOrigin,
+  indexesTarget,
+  direction
+) => {
+  let rows = convertTableNodeToArrayOfRows(table.node);
+
+  rows = moveRowInArrayOfRows(rows, indexesOrigin, indexesTarget, direction);
+
+  return convertArrayOfRowsToTableNode(table.node, rows);
+};
+
+const moveRowInArrayOfRows = (
+  rows,
+  indexesOrigin,
+  indexesTarget,
+  directionOverride
+) => {
+  let direction = indexesOrigin[0] > indexesTarget[0] ? -1 : 1;
+
+  const rowsExtracted = rows.splice(indexesOrigin[0], indexesOrigin.length);
+  const positionOffset = rowsExtracted.length % 2 === 0 ? 1 : 0;
+  let target;
+
+  if (directionOverride === -1 && direction === 1) {
+    target = indexesTarget[0] - 1;
+  } else if (directionOverride === 1 && direction === -1) {
+    target = indexesTarget[indexesTarget.length - 1] - positionOffset + 1;
+  } else {
+    target =
+      direction === -1
+        ? indexesTarget[0]
+        : indexesTarget[indexesTarget.length - 1] - positionOffset;
+  }
+
+  rows.splice.apply(rows, [target, 0].concat(rowsExtracted));
+  return rows;
+};
+
+export const checkInvalidMovements = (
+  originIndex,
+  targetIndex,
+  targets,
+  type
+) => {
+  const direction = originIndex > targetIndex ? -1 : 1;
+  const errorMessage = `Target position is invalid, you can't move the ${type} ${originIndex} to ${targetIndex}, the target can't be split. You could use tryToFit option.`;
+
+  if (direction === 1) {
+    if (targets.slice(0, targets.length - 1).indexOf(targetIndex) !== -1) {
+      throw new Error(errorMessage);
+    }
+  } else {
+    if (targets.slice(1).indexOf(targetIndex) !== -1) {
+      throw new Error(errorMessage);
+    }
+  }
+
+  return true;
+};

--- a/src/index.js
+++ b/src/index.js
@@ -2,4 +2,9 @@ export * from './selection';
 export * from './node';
 export * from './table';
 export * from './transforms';
-export { isNodeSelection, canInsert } from './helpers';
+export {
+  isNodeSelection,
+  canInsert,
+  convertTableNodeToArrayOfRows,
+  convertArrayOfRowsToTableNode
+} from './helpers';

--- a/src/table.js
+++ b/src/table.js
@@ -15,7 +15,10 @@ import {
   tableNodeTypes,
   findTableClosestToPos,
   createCell,
-  isRectSelected
+  isRectSelected,
+  moveTableRow,
+  moveTableColumn,
+  checkInvalidMovements
 } from './helpers';
 
 // :: (selection: Selection) → ?{pos: number, start: number, node: ProseMirrorNode}
@@ -312,6 +315,341 @@ export const addColumnAt = columnIndex => tr => {
     }
   }
   return tr;
+};
+
+// :: (originRowIndex: number, targetRowIndex: targetColumnIndex, options?: MovementOptions) → (tr: Transaction) → Transaction
+// Returns a new transaction that moves the origin row to the target index;
+//
+// by default "tryToFit" is false, that means if you try to move a row to a place
+// where we will need to split a row with merged cells it'll throw an exception, for example:
+//
+//      ____________________________
+//     |      |      |             |
+//  0  |  A1  |  B1  |     C1      |
+//     |______|______|______ ______|
+//     |      |             |      |
+//  1  |  A2  |     B2      |      |
+//     |______|______ ______|      |
+//     |      |      |      |  D1  |
+//  2  |  A3  |  B3  |  C2  |      |
+//     |______|______|______|______|
+//
+// if you try to move the row 0 to the row index 1 with tryToFit false,
+// it'll throw an exception since you can't split the row 1;
+// but if "tryToFit" is true, it'll move the row using the current direction.
+//
+// We defined current direction using the target and origin values
+// if the origin is greater than the target, that means the course is `bottom-to-top`,
+// so the `tryToFit` logic will use this direction to determine
+// if we should move the column to the right or the left.
+//
+// for example, if you call the function using `moveRow(0, 1, { tryToFit: true })`
+// the result will be:
+//      ____________________________
+//     |      |             |      |
+//  0  |  A2  |     B2      |      |
+//     |______|______ ______|      |
+//     |      |      |      |  D1  |
+//  1  |  A3  |  B3  |  C2  |      |
+//     |______|______|______|______|
+//     |      |      |             |
+//  2  |  A1  |  B1  |     C1      |
+//     |______|______|______ ______|
+//
+// since we could put the row zero on index one,
+// we pushed to the best place to fit the row index 0,
+// in this case, row index 2.
+//
+//
+// -------- HOW TO OVERRIDE DIRECTION --------
+//
+// If you set "tryToFit" to "true", it will try to figure out the best direction
+// place to fit using the origin and target index, for example:
+//
+//
+//      ____________________________
+//     |      |      |             |
+//  0  |  A1  |  B1  |     C1      |
+//     |______|______|______ ______|
+//     |      |             |      |
+//  1  |  A2  |     B2      |      |
+//     |______|______ ______|      |
+//     |      |      |      |  D1  |
+//  2  |  A3  |  B3  |  C2  |      |
+//     |______|______|______|______|
+//     |      |             |      |
+//  3  |  A4  |     B4      |      |
+//     |______|______ ______|      |
+//     |      |      |      |  D2  |
+//  4  |  A5  |  B5  |  C3  |      |
+//     |______|______|______|______|
+//
+//
+// If you try to move the row 0 to row index 4 with "tryToFit" enabled, by default,
+// the code will put it on after the merged rows,
+// but you can override it using the "direction" option.
+//
+// -1: Always put the origin before the target
+//      ____________________________
+//     |      |             |      |
+//  0  |  A2  |     B2      |      |
+//     |______|______ ______|      |
+//     |      |      |      |  D1  |
+//  1  |  A3  |  B3  |  C2  |      |
+//     |______|______|______|______|
+//     |      |      |             |
+//  2  |  A1  |  B1  |     C1      |
+//     |______|______|______ ______|
+//     |      |             |      |
+//  3  |  A4  |     B4      |      |
+//     |______|______ ______|      |
+//     |      |      |      |  D2  |
+//  4  |  A5  |  B5  |  C3  |      |
+//     |______|______|______|______|
+//
+//  0: Automatically decide the best place to fit
+//      ____________________________
+//     |      |             |      |
+//  0  |  A2  |     B2      |      |
+//     |______|______ ______|      |
+//     |      |      |      |  D1  |
+//  1  |  A3  |  B3  |  C2  |      |
+//     |______|______|______|______|
+//     |      |             |      |
+//  2  |  A4  |     B4      |      |
+//     |______|______ ______|      |
+//     |      |      |      |  D2  |
+//  3  |  A5  |  B5  |  C3  |      |
+//     |______|______|______|______|
+//     |      |      |             |
+//  4  |  A1  |  B1  |     C1      |
+//     |______|______|______ ______|
+//
+//  1: Always put the origin after the target
+//      ____________________________
+//     |      |             |      |
+//  0  |  A2  |     B2      |      |
+//     |______|______ ______|      |
+//     |      |      |      |  D1  |
+//  1  |  A3  |  B3  |  C2  |      |
+//     |______|______|______|______|
+//     |      |             |      |
+//  2  |  A4  |     B4      |      |
+//     |______|______ ______|      |
+//     |      |      |      |  D2  |
+//  3  |  A5  |  B5  |  C3  |      |
+//     |______|______|______|______|
+//     |      |      |             |
+//  4  |  A1  |  B1  |     C1      |
+//     |______|______|______ ______|
+//
+// ```javascript
+// dispatch(
+//   moveRow(x, y, options)(state.tr)
+// );
+// ```
+export const moveRow = (originRowIndex, targetRowIndex, opts) => tr => {
+  const defaultOptions = { tryToFit: false, direction: 0 };
+  const options = Object.assign(defaultOptions, opts);
+  const table = findTable(tr.selection);
+  if (!table) {
+    return tr;
+  }
+
+  const { indexes: indexesOriginRow } = getSelectionRangeInRow(originRowIndex)(
+    tr
+  );
+  const { indexes: indexesTargetRow } = getSelectionRangeInRow(targetRowIndex)(
+    tr
+  );
+
+  if (indexesOriginRow.indexOf(targetRowIndex) > -1) {
+    return tr;
+  }
+
+  if (!options.tryToFit && indexesTargetRow.length > 1) {
+    checkInvalidMovements(
+      originRowIndex,
+      targetRowIndex,
+      indexesTargetRow,
+      'row'
+    );
+  }
+
+  const newTable = moveTableRow(
+    table,
+    indexesOriginRow,
+    indexesTargetRow,
+    options.direction
+  );
+
+  return cloneTr(tr).replaceWith(
+    table.pos,
+    table.pos + table.node.nodeSize,
+    newTable
+  );
+};
+
+// :: (originColumnIndex: number, targetColumnIndex: targetColumnIndex, options?: MovementOptions) → (tr: Transaction) → Transaction
+// Returns a new transaction that moves the origin column to the target index;
+//
+// by default "tryToFit" is false, that means if you try to move a column to a place
+// where we will need to split a column with merged cells it'll throw an exception, for example:
+//
+//    0      1         2
+//  ____________________________
+// |      |      |             |
+// |  A1  |  B1  |     C1      |
+// |______|______|______ ______|
+// |      |             |      |
+// |  A2  |     B2      |      |
+// |______|______ ______|      |
+// |      |      |      |  D1  |
+// |  A3  |  B3  |  C2  |      |
+// |______|______|______|______|
+//
+//
+// if you try to move the column 0 to the column index 1 with tryToFit false,
+// it'll throw an exception since you can't split the column 1;
+// but if "tryToFit" is true, it'll move the column using the current direction.
+//
+// We defined current direction using the target and origin values
+// if the origin is greater than the target, that means the course is `right-to-left`,
+// so the `tryToFit` logic will use this direction to determine
+// if we should move the column to the right or the left.
+//
+// for example, if you call the function using `moveColumn(0, 1, { tryToFit: true })`
+// the result will be:
+//
+//    0       1             2
+// _____________________ _______
+// |      |             |      |
+// |  B1  |     C1      |  A1  |
+// |______|______ ______|______|
+// |             |      |      |
+// |     B2      |      |  A2  |
+// |______ ______|      |______|
+// |      |      |  D1  |      |
+// |  B3  |  C2  |      |  A3  |
+// |______|______|______|______|
+//
+// since we could put the column zero on index one,
+// we pushed to the best place to fit the column 0, in this case, column index 2.
+//
+// -------- HOW TO OVERRIDE DIRECTION --------
+//
+// If you set "tryToFit" to "true", it will try to figure out the best direction
+// place to fit using the origin and target index, for example:
+//
+//
+//     0      1       2     3      4      5       6
+//   _________________________________________________
+//  |      |      |             |      |             |
+//  |  A1  |  B1  |     C1      |  E1  |     F1      |
+//  |______|______|______ ______|______|______ ______|
+//  |      |             |      |             |      |
+//  |  A2  |     B2      |      |     E2      |      |
+//  |______|______ ______|      |______ ______|      |
+//  |      |      |      |  D1  |      |      |  G2  |
+//  |  A3  |  B3  |  C3  |      |  E3  |  F3  |      |
+//  |______|______|______|______|______|______|______|
+//
+//
+// If you try to move the column 0 to column index 5 with "tryToFit" enabled, by default,
+// the code will put it on after the merged columns,
+// but you can override it using the "direction" option.
+//
+// -1: Always put the origin before the target
+//
+//     0      1       2     3      4      5       6
+//   _________________________________________________
+//  |      |             |      |      |             |
+//  |  B1  |     C1      |  A1  |  E1  |     F1      |
+//  |______|______ ______|______|______|______ ______|
+//  |             |      |      |             |      |
+//  |     B2      |      |  A2  |     E2      |      |
+//  |______ ______|      |______|______ ______|      |
+//  |      |      |  D1  |      |      |      |  G2  |
+//  |  B3  |  C3  |      |  A3  |  E3  |  F3  |      |
+//  |______|______|______|______|______|______|______|
+//
+//  0: Automatically decide the best place to fit
+//
+//     0      1       2     3      4      5       6
+//   _________________________________________________
+//  |      |             |      |             |      |
+//  |  B1  |     C1      |  E1  |     F1      |  A1  |
+//  |______|______ ______|______|______ ______|______|
+//  |             |      |             |      |      |
+//  |     B2      |      |     E2      |      |  A2  |
+//  |______ ______|      |______ ______|      |______|
+//  |      |      |  D1  |      |      |  G2  |      |
+//  |  B3  |  C3  |      |  E3  |  F3  |      |  A3  |
+//  |______|______|______|______|______|______|______|
+//
+//  1: Always put the origin after the target
+//
+//     0      1       2     3      4      5       6
+//   _________________________________________________
+//  |      |             |      |             |      |
+//  |  B1  |     C1      |  E1  |     F1      |  A1  |
+//  |______|______ ______|______|______ ______|______|
+//  |             |      |             |      |      |
+//  |     B2      |      |     E2      |      |  A2  |
+//  |______ ______|      |______ ______|      |______|
+//  |      |      |  D1  |      |      |  G2  |      |
+//  |  B3  |  C3  |      |  E3  |  F3  |      |  A3  |
+//  |______|______|______|______|______|______|______|
+//
+// ```javascript
+// dispatch(
+//   moveColumn(x, y, options)(state.tr)
+// );
+// ```
+export const moveColumn = (
+  originColumnIndex,
+  targetColumnIndex,
+  opts
+) => tr => {
+  const defaultOptions = { tryToFit: false, direction: 0 };
+  const options = Object.assign(defaultOptions, opts);
+  const table = findTable(tr.selection);
+  if (!table) {
+    return tr;
+  }
+
+  const { indexes: indexesOriginColumn } = getSelectionRangeInColumn(
+    originColumnIndex
+  )(tr);
+  const { indexes: indexesTargetColumn } = getSelectionRangeInColumn(
+    targetColumnIndex
+  )(tr);
+
+  if (indexesOriginColumn.indexOf(targetColumnIndex) > -1) {
+    return tr;
+  }
+
+  if (!options.tryToFit && indexesTargetColumn.length > 1) {
+    checkInvalidMovements(
+      originColumnIndex,
+      targetColumnIndex,
+      indexesTargetColumn,
+      'column'
+    );
+  }
+
+  const newTable = moveTableColumn(
+    table,
+    indexesOriginColumn,
+    indexesTargetColumn,
+    options.direction
+  );
+
+  return cloneTr(tr).replaceWith(
+    table.pos,
+    table.pos + table.node.nodeSize,
+    newTable
+  );
 };
 
 // :: (rowIndex: number, clonePreviousRow?: boolean) → (tr: Transaction) → Transaction

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -11,6 +11,8 @@ export type NodeWithPos = {pos: number, node: ProsemirrorNode};
 
 export type CellTransform = (cell: ContentNodeWithPos, tr: Transaction) => Transaction;
 
+export type MovementOptions = { tryToFit: boolean, direction?: -1 | 0 | 1 };
+
 // Selection
 export function findParentNode(predicate: Predicate): (selection: Selection) => ContentNodeWithPos | undefined;
 
@@ -82,6 +84,10 @@ export function emptyCell(cell: ContentNodeWithPos, schema: Schema): (tr: Transa
 
 export function addColumnAt(columnIndex: number): (tr: Transaction) => Transaction;
 
+export function moveRow(originRowIndex: number, targetRowIndex: number, options?: MovementOptions): (tr: Transaction) => Transaction;
+
+export function moveColumn(originColumnIndex: number, targetColumnIndex: number, options?: MovementOptions): (tr: Transaction) => Transaction;
+
 export function addRowAt(rowIndex: number, clonePreviousRow?: boolean): (tr: Transaction) => Transaction;
 
 export function cloneRowAt(cloneRowIndex: number): (tr: Transaction) => Transaction;
@@ -126,6 +132,10 @@ export function replaceParentNodeOfType(nodeType: NodeType | NodeType[], node: P
 export function removeSelectedNode(tr: Transaction): Transaction;
 
 export function replaceSelectedNode(node: ProsemirrorNode): (tr: Transaction) => Transaction;
+
+export function convertTableNodeToArrayOfRows(tableNode: ProsemirrorNode): ProsemirrorNode[];
+
+export function convertArrayOfRowsToTableNode(tableNode: ProsemirrorNode, tableArray: ProsemirrorNode[]): ProsemirrorNode;
 
 export function canInsert($pos: ResolvedPos, node: ProsemirrorNode | Fragment): boolean;
 


### PR DESCRIPTION
This PR will add two necessary functions to work with Prosemirror Tables `moveRow` and `moveColumn`. 

Those functions need only an origin index and target, all calculations about merged cell and rows are deal accurately inside. All  table bellows were tests, and they have units tests to cover it: 

### table 3x3 
- [x] without any merged columns or rows
- [x] with one merged columns
- [x] with table header 
- [x] with  one merged row
- [x] with two merged rows
- [x] with three merged rows

### table 3x5 
- [x] with two merged rows and two merged columns

### table 3x4
- [x] with one merged column and two merged rows
- [x] with two merged columns

All tested with `left-to-right` and `right-to-left` movement.


P.S: For some weird reason on `builddocs` I couldn't add a babel transform to use spread operations, so I'm using the old javascript hacky to splice: 