### PR TITLE
Update safeInsert replace w/ Fragment support

### DIFF
--- a/README.md
+++ b/README.md
@@ -822,7 +822,7 @@ npm install prosemirror-utils
    ```
 
 
- * **`replaceSelectedNode`**`(node: ProseMirrorNode) → fn(tr: Transaction) → Transaction`\
+ * **`replaceSelectedNode`**`(content: ProseMirrorNode | ProseMirrorFragment) → fn(tr: Transaction) → Transaction`\
    Returns a new transaction that replaces selected node with a given `node`, keeping NodeSelection on the new `node`.
    It will return the original transaction if either current selection is not a NodeSelection or replacing is not possible.
 

--- a/__tests__/transforms.js
+++ b/__tests__/transforms.js
@@ -10,7 +10,6 @@ import {
   th,
   tdCursor,
   tdEmpty,
-  thEmpty,
   blockquote,
   atomInline,
   atomBlock
@@ -541,6 +540,26 @@ describe('transforms', () => {
       const newTr = replaceSelectedNode(node)(tr);
       expect(newTr).not.toBe(tr);
       expect(newTr.doc).toEqualDocument(doc(p('one'), p('new'), p('two')));
+    });
+
+    it('should replace selected node with the given `fragment`', () => {
+      const { state } = createEditor(doc(p('one'), p('test'), p('two')));
+      const tr = state.tr.setSelection(NodeSelection.create(state.doc, 5));
+      const fragment = Fragment.fromArray([
+        state.schema.nodes.paragraph.createChecked(
+          {},
+          state.schema.text('new')
+        ),
+        state.schema.nodes.paragraph.createChecked(
+          {},
+          state.schema.text('paragraphs')
+        )
+      ]);
+      const newTr = replaceSelectedNode(fragment)(tr);
+      expect(newTr).not.toBe(tr);
+      expect(newTr.doc).toEqualDocument(
+        doc(p('one'), p('new'), p('paragraphs'), p('two'))
+      );
     });
   });
 

--- a/__tests__/transforms.js
+++ b/__tests__/transforms.js
@@ -15,7 +15,7 @@ import {
   atomInline,
   atomBlock
 } from '../test-helpers';
-import { NodeSelection, TextSelection } from 'prosemirror-state';
+import { NodeSelection } from 'prosemirror-state';
 import { Fragment } from 'prosemirror-model';
 import {
   removeParentNodeOfType,

--- a/src/transforms.js
+++ b/src/transforms.js
@@ -121,9 +121,10 @@ export const setTextSelection = (position, dir = 1) => tr => {
 };
 
 const isSelectableNode = node => node.type && node.type.spec.selectable;
+const shouldSelectNode = node => isSelectableNode(node) && node.type.isLeaf;
 
 const setSelection = (node, pos, tr) => {
-  if (isSelectableNode(node)) {
+  if (shouldSelectNode(node)) {
     return tr.setSelection(new NodeSelection(tr.doc.resolve(pos)));
   }
   return setTextSelection(pos)(tr);


### PR DESCRIPTION
Previously we would blank attempt to add a NodeSelection after replacing it, this should only be true for leaf nodes, otherwise continue with a TextSelection. Also adding support for Fragments inside Node replacement.