### PR TITLE
 Fixed emptyCell not working after prosemirror-model@1.7.1 update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /node_modules
 /dist
+.vscode

--- a/package-lock.json
+++ b/package-lock.json
@@ -6239,9 +6239,9 @@
       }
     },
     "prosemirror-model": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.6.3.tgz",
-      "integrity": "sha512-iqIml664X9MUVGLz2nzK4xfAofX8+o7gs2mi2/k+pVD0qZ7th1Jm5eG3AsqWoEUIZuWeaOWCKpBl/dPnhIIWew==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.7.1.tgz",
+      "integrity": "sha512-hYrZPbJvdo2QWERmkCuS80BEf5Rcf3+S28ETr4xu8XKPYjmU6aeQn23G1Fu/2rwqUmk5ZyWYo2nyEsN+Cdv2Qg==",
       "dev": true,
       "requires": {
         "orderedmap": "1.0.0"
@@ -6253,7 +6253,7 @@
       "integrity": "sha512-xTFjtuLZgcRS4MoDbUyI9NSk/k/ACLGKZQcDXH18ctM9BOmP4z5rGZcA014fCF2FnMFOU+lKwusL0JjVrEectQ==",
       "dev": true,
       "requires": {
-        "prosemirror-model": "1.6.3"
+        "prosemirror-model": "1.7.1"
       }
     },
     "prosemirror-schema-list": {
@@ -6262,7 +6262,7 @@
       "integrity": "sha512-AiLIX6qm6PEeDtMCKZLcSLi55WXo1ls7DnRK+4hSkoi0IIzNdxGsRlecCd3MzEu//DVz3nAEh+zEmslyW+uk8g==",
       "dev": true,
       "requires": {
-        "prosemirror-model": "1.6.3",
+        "prosemirror-model": "1.7.1",
         "prosemirror-transform": "1.1.3"
       }
     },
@@ -6272,7 +6272,7 @@
       "integrity": "sha512-j8aC/kf9BJSCQau485I/9pj39XQoce+TqH5xzekT7WWFARTsRYFLJtiXBcCKakv1VSeev+sC3bJP0pLfz7Ft8g==",
       "dev": true,
       "requires": {
-        "prosemirror-model": "1.6.3",
+        "prosemirror-model": "1.7.1",
         "prosemirror-transform": "1.1.3"
       }
     },
@@ -6283,7 +6283,7 @@
       "dev": true,
       "requires": {
         "prosemirror-keymap": "1.0.1",
-        "prosemirror-model": "1.6.3",
+        "prosemirror-model": "1.7.1",
         "prosemirror-state": "1.2.2",
         "prosemirror-transform": "1.1.3",
         "prosemirror-view": "1.6.7"
@@ -6295,7 +6295,7 @@
       "integrity": "sha512-ydO7fa0He2DD5riaPvnDEElVD8R8hgAt0/+fOzUdPKa/dqsUblOdY+luC9knT86Jwg5eRMPBmLYWIvJYUKhNqw==",
       "dev": true,
       "requires": {
-        "prosemirror-model": "1.6.3",
+        "prosemirror-model": "1.7.1",
         "prosemirror-schema-basic": "1.0.0",
         "prosemirror-schema-list": "1.0.1"
       }
@@ -6306,7 +6306,7 @@
       "integrity": "sha512-1O6Di5lOL1mp4nuCnQNkHY7l2roIW5y8RH4ZG3hMYmkmDEWzTaFFnxxAAHsE5ipGLBSRcTlP7SsDhYBIdSuLpQ==",
       "dev": true,
       "requires": {
-        "prosemirror-model": "1.6.3"
+        "prosemirror-model": "1.7.1"
       }
     },
     "prosemirror-view": {
@@ -6315,7 +6315,7 @@
       "integrity": "sha512-M+6HPb6DSe731E3y2wKDlzojhBevIi911650O3ivSucOIcMw0/5M0hLEfN9/1D0RILuiHUjvCvbpTZTnfzBXeg==",
       "dev": true,
       "requires": {
-        "prosemirror-model": "1.6.3",
+        "prosemirror-model": "1.7.1",
         "prosemirror-state": "1.2.2",
         "prosemirror-transform": "1.1.3"
       }

--- a/src/table.js
+++ b/src/table.js
@@ -7,7 +7,6 @@ import {
   removeRow
 } from 'prosemirror-tables';
 import { Selection } from 'prosemirror-state';
-import { Slice } from 'prosemirror-model';
 import { findParentNode, findParentNodeClosestToPos } from './selection';
 import { setTextSelection, safeInsert } from './transforms';
 import {
@@ -324,13 +323,9 @@ export const selectTable = tr => {
 // ```
 export const emptyCell = (cell, schema) => tr => {
   if (cell) {
-    const content = tableNodeTypes(schema).cell.createAndFill().content;
+    const { content } = tableNodeTypes(schema).cell.createAndFill();
     if (!cell.node.content.eq(content)) {
-      tr.replaceWith(
-        cell.pos,
-        cell.pos + cell.node.nodeSize - 1,
-        new Slice(content, 0, 0)
-      );
+      tr.replaceWith(cell.pos + 1, cell.pos + cell.node.nodeSize, content);
       return cloneTr(tr);
     }
   }


### PR DESCRIPTION
The following commit on `prosemirror-model@1.7.1` has made explicit that we're doing something wrong in our `emptyCell()`, as we can't pass a `Slice` to `tr.replaceWith()`, it must be a `Node` or `Fragment`.

https://github.com/ProseMirror/prosemirror-model/commit/8bf01f1b58e81ffabf64e2944538fca80fc578d8
