### PR TITLE
Add new method to copy rows in a table with configurable options

### DIFF
--- a/README.md
+++ b/README.md
@@ -624,7 +624,7 @@ npm install prosemirror-utils
  * **`copyRow`**`(insertNewRowIndex: number, rowToBeClonedIndex: number, options: ?CopyRowOptions) → fn(tr: Transaction) → Transaction`\
    Returns a new transaction that adds a new row at index `insertNewRowIndex`.
    Copying the cells from any row using `rowToBeClonedIndex`,
-   you can configure how that copy should working by the options:
+   you can configure how that copy should work by the options:
 
    ```javascript
    options = {

--- a/__tests__/table_copyRow.js
+++ b/__tests__/table_copyRow.js
@@ -247,6 +247,14 @@ describe('table', () => {
         tr = editor.state.tr;
       });
 
+      describe('when the rowToBeClonedIndex is not the previous row', () => {
+        it('should throw an error', () => {
+          expect(() => {
+            copyRow(4, 1, { expandRowspanFromClonedRow: true })(tr);
+          }).toThrow();
+        });
+      });
+
       describe('with flag true', () => {
         it('should increase previous rowspan', () => {
           const newTr = copyRow(4, 3, { expandRowspanFromClonedRow: true })(tr);

--- a/__tests__/table_copyRow.js
+++ b/__tests__/table_copyRow.js
@@ -1,0 +1,516 @@
+import {
+  createEditor,
+  doc,
+  p,
+  table,
+  tr as row,
+  td,
+  tdEmpty,
+  thEmpty,
+  th
+} from '../test-helpers';
+import { TableMap } from 'prosemirror-tables';
+import { getCellsInRow, findTable, copyRow } from '../src';
+
+describe('table', () => {
+  describe('#copyRow', () => {
+    it('should ignore colspan from previous row by default', () => {
+      const {
+        state: { tr },
+        view
+      } = createEditor(
+        doc(
+          table(
+            row(td(p('1<cursor>')), td(p('2'))),
+            row(td({ background: '#eeeaaa', colspan: 2 }, p('3')))
+          )
+        )
+      );
+
+      const newTr = copyRow(2, 1)(tr);
+      const cells = getCellsInRow(2)(newTr.selection);
+
+      expect(cells).toHaveLength(2);
+    });
+
+    it('should keep colspan on table headers', () => {
+      const {
+        state: { tr }
+      } = createEditor(
+        doc(
+          table(
+            row(td(p('1<cursor>')), td(p('2'))),
+            row(td({ colspan: 2, pretty: true }, p('3')))
+          )
+        )
+      );
+
+      const options = {
+        keepColspan: true
+      };
+
+      const newTr = copyRow(2, 1, options)(tr);
+
+      expect(newTr.doc).toEqualDocument(
+        doc(
+          table(
+            row(td(p('1')), td(p('2'))),
+            row(td({ colspan: 2, pretty: true }, p('3'))),
+            row(td({ colspan: 2, pretty: true }, p()))
+          )
+        )
+      );
+    });
+
+    it('should keep colspan', () => {
+      const {
+        state: { tr },
+        view
+      } = createEditor(
+        doc(
+          table(
+            row(
+              td({ rowspan: 2 }, p('a1')),
+              td({ rowspan: 2 }, p('a2')),
+              td(p('a3')),
+              td(p('a4')),
+              td(p('a5')),
+              td(p('a6'))
+            ),
+            row(td({ colspan: 2 }, p('b1')), td({ colspan: 2 }, p('b2')))
+          )
+        )
+      );
+
+      const options = {
+        keepColspan: true
+      };
+
+      const newTr = copyRow(2, 1, options)(tr);
+
+      expect(newTr.doc).toEqualDocument(
+        doc(
+          table(
+            row(
+              td({ rowspan: 2 }, p('a1')),
+              td({ rowspan: 2 }, p('a2')),
+              td(p('a3')),
+              td(p('a4')),
+              td(p('a5')),
+              td(p('a6'))
+            ),
+            row(td({ colspan: 2 }, p('b1')), td({ colspan: 2 }, p('b2'))),
+            row(
+              tdEmpty,
+              tdEmpty,
+              td({ colspan: 2 }, p('')),
+              td({ colspan: 2 }, p(''))
+            )
+          )
+        )
+      );
+    });
+
+    describe('clone row with cell with rowspan', () => {
+      it('should keep rowspan case 1', () => {
+        const {
+          state: { tr },
+          view
+        } = createEditor(
+          doc(
+            table(
+              row(
+                td({ rowspan: 2 }, p('a1')),
+                td({ rowspan: 2 }, p('a2')),
+                td(p('a3')),
+                td(p('a4'))
+              ),
+              row(td({ rowspan: 2 }, p('b1')), td(p('b2'))),
+              row(td(p('c1')), td(p('c2')), td(p('c3')))
+            )
+          )
+        );
+
+        const newTr = copyRow(2, 1)(tr);
+
+        expect(newTr.doc).toEqualDocument(
+          doc(
+            table(
+              row(
+                td({ rowspan: 2 }, p('a1')),
+                td({ rowspan: 2 }, p('a2')),
+                td(p('a3')),
+                td(p('a4'))
+              ),
+              row(td({ rowspan: 3 }, p('b1')), td(p('b2'))),
+              row(tdEmpty, tdEmpty, tdEmpty),
+              row(td(p('c1')), td(p('c2')), td(p('c3')))
+            )
+          )
+        );
+      });
+
+      it('should keep rowspan case 2', () => {
+        const {
+          state: { tr },
+          view
+        } = createEditor(
+          doc(
+            table(
+              row(
+                td({ rowspan: 3 }, p('a1')),
+                td({ rowspan: 3 }, p('a2')),
+                td(p('a3')),
+                td(p('a4'))
+              ),
+              row(td({ rowspan: 2 }, p('b1')), td(p('b2'))),
+              row(td(p('c1')))
+            )
+          )
+        );
+
+        const newTr = copyRow(2, 1)(tr);
+
+        expect(newTr.doc).toEqualDocument(
+          doc(
+            table(
+              row(
+                td({ rowspan: 4 }, p('a1')),
+                td({ rowspan: 4 }, p('a2')),
+                td(p('a3')),
+                td(p('a4'))
+              ),
+              row(td({ rowspan: 3 }, p('b1')), td(p('b2'))),
+              row(tdEmpty),
+              row(td(p('c1')))
+            )
+          )
+        );
+      });
+
+      it('should not keep rowspan from last row', () => {
+        const {
+          state: { tr },
+          view
+        } = createEditor(
+          doc(
+            table(
+              row(
+                td({ rowspan: 3 }, p('a1')),
+                td({ rowspan: 3 }, p('a2')),
+                td(p('a3')),
+                td(p('a4'))
+              ),
+              row(td({ rowspan: 2 }, p('b1')), td(p('b2'))),
+              row(td(p('c1')))
+            )
+          )
+        );
+
+        const newTr = copyRow(3, 2)(tr);
+
+        expect(newTr.doc).toEqualDocument(
+          doc(
+            table(
+              row(
+                td({ rowspan: 3 }, p('a1')),
+                td({ rowspan: 3 }, p('a2')),
+                td(p('a3')),
+                td(p('a4'))
+              ),
+              row(td({ rowspan: 2 }, p('b1')), td(p('b2'))),
+              row(td(p('c1'))),
+              row(tdEmpty, tdEmpty, tdEmpty, tdEmpty)
+            )
+          )
+        );
+      });
+    });
+
+    describe('expandRowspanFromClonedRow', () => {
+      let tr;
+
+      beforeEach(() => {
+        const editor = createEditor(
+          doc(
+            table(
+              row(td(p('a1')), td(p('a2')), td(p('a3'))),
+              row(td(p('b1')), td(p('b2')), td({ rowspan: 3 }, p('b3'))),
+              row(td(p('c1')), td(p('c2'))),
+              row(td(p('d1')), td({ rowspan: 2 }, p('d2'))),
+              row(td(p('e1')), td(p('e2'))),
+              row(td(p('f1')), td(p('f2')), td(p('f3')))
+            )
+          )
+        );
+
+        tr = editor.state.tr;
+      });
+
+      describe('with flag true', () => {
+        it('should increase previous rowspan', () => {
+          const newTr = copyRow(4, 3, { expandRowspanFromClonedRow: true })(tr);
+
+          expect(newTr.doc).toEqualDocument(
+            doc(
+              table(
+                row(td(p('a1')), td(p('a2')), td(p('a3'))),
+                row(td(p('b1')), td(p('b2')), td({ rowspan: 4 }, p('b3'))),
+                row(td(p('c1')), td(p('c2'))),
+                row(td(p('d1')), td({ rowspan: 3 }, p('d2'))),
+                row(tdEmpty),
+                row(td(p('e1')), td(p('e2'))),
+                row(td(p('f1')), td(p('f2')), td(p('f3')))
+              )
+            )
+          );
+        });
+      });
+
+      describe('with flag false', () => {
+        it('should not increase previous rowspan', () => {
+          const newTr = copyRow(4, 3)(tr);
+
+          expect(newTr.doc).toEqualDocument(
+            doc(
+              table(
+                row(td(p('a1')), td(p('a2')), td(p('a3'))),
+                row(td(p('b1')), td(p('b2')), td({ rowspan: 3 }, p('b3'))),
+                row(td(p('c1')), td(p('c2'))),
+                row(td(p('d1')), td({ rowspan: 3 }, p('d2'))),
+                row(tdEmpty, tdEmpty),
+                row(td(p('e1')), td(p('e2'))),
+                row(td(p('f1')), td(p('f2')), td(p('f3')))
+              )
+            )
+          );
+        });
+      });
+    });
+
+    describe('getNewCell', () => {
+      let tr;
+
+      beforeEach(() => {
+        ({
+          state: { tr }
+        } = createEditor(
+          doc(
+            table(
+              row(td(p('a1')), td(p('a2')), td(p('a3'))),
+              row(td(p('b1')), td(p('b2')), td(p('b3'))),
+              row(td(p('c1')), td(p('c2')), td(p('c3')))
+            )
+          )
+        ));
+      });
+
+      describe('when it returns null', () => {
+        it('should create a empty row with empty cells', () => {
+          const options = {
+            getNewCell: () => {
+              return null;
+            }
+          };
+
+          const newTr = copyRow(0, 2, options)(tr);
+
+          expect(newTr.doc).toEqualDocument(
+            doc(
+              table(
+                row(tdEmpty, tdEmpty, tdEmpty),
+                row(td(p('a1')), td(p('a2')), td(p('a3'))),
+                row(td(p('b1')), td(p('b2')), td(p('b3'))),
+                row(td(p('c1')), td(p('c2')), td(p('c3')))
+              )
+            )
+          );
+        });
+      });
+
+      describe('when it returns a valid cellNode', () => {
+        it('should create the new row with the cell content', () => {
+          const options = {
+            getNewCell: cell => {
+              return cell.type.createAndFill({}, p('---'));
+            }
+          };
+
+          const newTr = copyRow(0, 2, options)(tr);
+
+          expect(newTr.doc).toEqualDocument(
+            doc(
+              table(
+                row(td(p('---')), td(p('---')), td(p('---'))),
+                row(td(p('a1')), td(p('a2')), td(p('a3'))),
+                row(td(p('b1')), td(p('b2')), td(p('b3'))),
+                row(td(p('c1')), td(p('c2')), td(p('c3')))
+              )
+            )
+          );
+        });
+      });
+
+      describe('when getNewCell is null', () => {
+        it('should use default attributes', () => {
+          const newTr = copyRow(2, 1)(tr);
+          const cells = getCellsInRow(2)(newTr.selection);
+
+          expect(cells).toHaveLength(3);
+
+          cells.forEach((cell, i) => {
+            expect(cell.node.attrs.background).toEqual(false);
+          });
+        });
+      });
+
+      it('should not replace colspan', () => {
+        const options = {
+          getNewCell: cell => {
+            return cell.type.createAndFill({ colspan: 3 });
+          }
+        };
+        const newTr = copyRow(2, 1, options)(tr);
+        const cells = getCellsInRow(2)(newTr.selection);
+
+        expect(cells).toHaveLength(3);
+        cells.forEach((cell, i) => {
+          expect(cell.node.attrs.colspan).not.toEqual(3);
+        });
+      });
+
+      it('should not replace rowspan', () => {
+        const options = {
+          getNewCell: cell => {
+            return cell.type.createAndFill({ rowspan: 3 });
+          }
+        };
+        const newTr = copyRow(2, 1, options)(tr);
+        const cells = getCellsInRow(2)(newTr.selection);
+
+        expect(cells).toHaveLength(3);
+        cells.forEach((cell, i) => {
+          expect(cell.node.attrs.colspan).not.toEqual(3);
+        });
+      });
+
+      describe('change background attributes', () => {
+        it('should use getNewCellAttributes to set the new attributes', () => {
+          const options = {
+            getNewCell: cell => {
+              return cell.type.createAndFill({ background: '#ffffff' });
+            }
+          };
+          const newTr = copyRow(2, 1, options)(tr);
+          const cells = getCellsInRow(2)(newTr.selection);
+
+          const expected = {
+            background: '#ffffff'
+          };
+
+          expect(cells).toHaveLength(3);
+
+          cells.forEach((cell, i) => {
+            expect(cell.node.attrs.background).toEqual('#ffffff');
+          });
+
+          expect(newTr.doc).toEqualDocument(
+            doc(
+              table(
+                row(td(p('a1')), td(p('a2')), td(p('a3'))),
+                row(td(p('b1')), td(p('b2')), td(p('b3'))),
+                row(
+                  td({ background: '#ffffff' }, p('')),
+                  td({ background: '#ffffff' }, p('')),
+                  td({ background: '#ffffff' }, p(''))
+                ),
+                row(td(p('c1')), td(p('c2')), td(p('c3')))
+              )
+            )
+          );
+        });
+      });
+    });
+
+    describe('table with header row', () => {
+      it('should copy table header cell type', () => {
+        const {
+          state: { tr },
+          view
+        } = createEditor(
+          doc(
+            table(
+              row(th(p('a1')), th(p('a2')), th(p('a3')), th(p('a4'))),
+              row(td(p('b1')), td(p('b2')), td(p('b3')), td(p('b4')))
+            )
+          )
+        );
+
+        const options = {};
+
+        const newTr = copyRow(1, 0, options)(tr);
+
+        expect(newTr.doc).toEqualDocument(
+          doc(
+            table(
+              row(th(p('a1')), th(p('a2')), th(p('a3')), th(p('a4'))),
+              row(thEmpty, thEmpty, thEmpty, thEmpty),
+              row(td(p('b1')), td(p('b2')), td(p('b3')), td(p('b4')))
+            )
+          )
+        );
+      });
+    });
+
+    describe('complex table', () => {
+      it('should transform and keep the table', () => {
+        const {
+          state: { tr },
+          view
+        } = createEditor(
+          doc(
+            table(
+              row(th(p('a1')), th(p('a2')), th(p('a3'))),
+              row(td(p('b1')), td(p('b2')), td({ rowspan: 4 }, p('b3'))),
+              row(td(p('c1')), td(p('c2'))),
+              row(td(p('d1')), td({ rowspan: 3 }, p('d2'))),
+              row(td(p('XXXX'))),
+              row(td(p('e1')), td(p('e2'))),
+              row(td(p('f1')), td(p('f2')), td(p('f3')))
+            )
+          )
+        );
+        const options = {
+          expandRowspanFromClonedRow: false,
+          keepColspan: true,
+          getNewCell(cell) {
+            return cell.type.createAndFill({ background: '#aaaeee' });
+          }
+        };
+
+        const newTr = copyRow(5, 4, options)(tr);
+
+        const newTable = findTable(newTr.selection);
+        const map = TableMap.get(newTable.node);
+        expect(map.problems).toBeNull();
+        expect(newTr.doc).toEqualDocument(
+          doc(
+            table(
+              row(th(p('a1')), th(p('a2')), th(p('a3'))),
+              row(td(p('b1')), td(p('b2')), td({ rowspan: 4 }, p('b3'))),
+              row(td(p('c1')), td(p('c2'))),
+              row(td(p('d1')), td({ rowspan: 4 }, p('d2'))),
+              row(td(p('XXXX'))),
+              row(
+                td({ background: '#aaaeee' }, p('')),
+                td({ background: '#aaaeee' }, p(''))
+              ),
+              row(td(p('e1')), td(p('e2'))),
+              row(td(p('f1')), td(p('f2')), td(p('f3')))
+            )
+          )
+        );
+      });
+    });
+  });
+});

--- a/__tests__/transforms.js
+++ b/__tests__/transforms.js
@@ -606,7 +606,8 @@ describe('transforms', () => {
             rowspan: 7,
             colwidth: null,
             pretty: true,
-            ugly: false
+            ugly: false,
+            background: false
           });
         }
       });

--- a/src/README.md
+++ b/src/README.md
@@ -98,7 +98,7 @@ npm install prosemirror-utils
 
 @addRowAt
 
-@cloneRowAt
+@copyRow
 
 @removeColumnAt
 
@@ -157,6 +157,10 @@ npm install prosemirror-utils
 @convertTableNodeToArrayOfRows
 
 @convertArrayOfRowsToTableNode
+
+### Deprecated methods
+
+@cloneRowAt
 
 ## License
 

--- a/src/table.js
+++ b/src/table.js
@@ -724,7 +724,7 @@ export const moveColumn = (
 // :: (insertNewRowIndex: number, rowToBeClonedIndex: number, options?: CopyRowOptions) → (tr: Transaction) → Transaction
 // Returns a new transaction that adds a new row at index `insertNewRowIndex`.
 // Copying the cells from any row using `rowToBeClonedIndex`,
-// you can configure how that copy should working by the options:
+// you can configure how that copy should work by the options:
 //
 // ```javascript
 // options = {

--- a/src/table.js
+++ b/src/table.js
@@ -737,6 +737,10 @@ export const moveColumn = (
 //   /**
 //    * To keep the deprecated behavior from `cloneRowAt`
 //    * that clones the row and increases the rowspan from the previous rows.
+//    *
+//    * To use that flag `rowToBeClonedIndex` need to be the previous row,
+//    * that's means: (rowToBeClonedIndex === insertNewRowIndex - 1).
+//    * If is not the function will throw a error.
 //    */
 //   expandRowspanFromClonedRow: false
 //   /**
@@ -784,6 +788,14 @@ export const copyRow = (
 
   if (insertNewRowIndex < 0 || insertNewRowIndex > map.height) {
     return tr;
+  }
+
+  const isRowToCopyThePreviousOne =
+    rowToBeClonedIndex === insertNewRowIndex - 1;
+  if (expandRowspanFromClonedRow && !isRowToCopyThePreviousOne) {
+    throw Error(
+      `To use the \`expandRowspanFromClonedRow\` you must always copy from the previous row. rowToBeClonedIndex: ${rowToBeClonedIndex} insertNewRowIndex: ${insertNewRowIndex}`
+    );
   }
 
   const tableNode = table.node;

--- a/test-helpers/index.js
+++ b/test-helpers/index.js
@@ -71,3 +71,42 @@ testHelpers.createEditor = doc => {
 
   return { state, view, ...doc.tag };
 };
+
+testHelpers.createEditorFactory = () => {
+  let view;
+  let place;
+  afterEach(() => {
+    if (view) {
+      view.destroy();
+    }
+
+    if (place && place.parentNode) {
+      place.parentNode.removeChild(place);
+    }
+  });
+
+  return doc => {
+    if (view) {
+      view.destroy();
+    }
+
+    const opa = document.body;
+    while (opa.firstChild) {
+      opa.removeChild(opa.firstChild);
+    }
+
+    if (place && place.parentNode) {
+      place.parentNode.removeChild(place);
+    }
+
+    place = document.body.appendChild(document.createElement('div'));
+    const state = EditorState.create({
+      doc,
+      schema,
+      selection: initSelection(doc)
+    });
+    view = new EditorView(place, { state });
+
+    return { state, view, ...doc.tag };
+  };
+};

--- a/test-helpers/schema.js
+++ b/test-helpers/schema.js
@@ -8,7 +8,8 @@ const { table, table_cell, table_header, table_row } = tableNodes({
   cellContent: 'block+',
   cellAttributes: {
     pretty: { default: true },
-    ugly: { default: false }
+    ugly: { default: false },
+    background: { default: false }
   }
 });
 

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -13,6 +13,12 @@ export type CellTransform = (cell: ContentNodeWithPos, tr: Transaction) => Trans
 
 export type MovementOptions = { tryToFit: boolean, direction?: -1 | 0 | 1 };
 
+export type CopyRowOptions = {
+  keepColspan?: boolean,
+  expandRowspanFromClonedRow?: boolean,
+  getNewCell?: (previousCellNode: ProsemirrorNode) => ProsemirrorNode,
+};
+
 // Selection
 export function findParentNode(predicate: Predicate): (selection: Selection) => ContentNodeWithPos | undefined;
 
@@ -91,6 +97,8 @@ export function moveColumn(originColumnIndex: number, targetColumnIndex: number,
 export function addRowAt(rowIndex: number, clonePreviousRow?: boolean): (tr: Transaction) => Transaction;
 
 export function cloneRowAt(cloneRowIndex: number): (tr: Transaction) => Transaction;
+
+export function copyRow(insertNewRowIndex: number, rowToBeClonedIndex: number, options?: CopyRowOptions): (tr: Transaction) => Transaction;
 
 export function removeColumnAt(columnIndex: number): (tr: Transaction) => Transaction;
 


### PR DESCRIPTION
Deprecated the `cloneRowAt` and added a configurable method to copy a row in table `copyRow`.


The `copyRow` will make this behavior possible:

![Screen Recording 2019-08-05 at 11 13 am](https://user-images.githubusercontent.com/3452187/62432291-3384b280-b772-11e9-9d0c-8d9bbb084b39.gif)

with this code:
```
copyRow(5, 4, {
      expandRowspanFromClonedRow: false,
      keepColspan: true,
      getNewCell(cell) {
        // We can do anything here, even add a new content if we want to
        return cell.type.createAndFill({ background: cell.attrs.background });
      },
    })(state.tr)
```


`cloneRowAt` is being deprecated because is an inflexible function with a strong opinative logic,
by default with same table we have only this behavior:
![Screen Recording 2019-08-05 at 11 19 am](https://user-images.githubusercontent.com/3452187/62432419-f66cf000-b772-11e9-9df8-a229039bf44c.gif)



