### PR TITLE
Fix convertTableNodeToArrayOfRows and convertArrayOfRowsToTableNode typing

### DIFF
--- a/typings.d.ts
+++ b/typings.d.ts
@@ -133,9 +133,9 @@ export function removeSelectedNode(tr: Transaction): Transaction;
 
 export function replaceSelectedNode(node: ProsemirrorNode): (tr: Transaction) => Transaction;
 
-export function convertTableNodeToArrayOfRows(tableNode: ProsemirrorNode): ProsemirrorNode[];
+export function convertTableNodeToArrayOfRows(tableNode: ProsemirrorNode): Array<Array<ProsemirrorNode | null>>;
 
-export function convertArrayOfRowsToTableNode(tableNode: ProsemirrorNode, tableArray: ProsemirrorNode[]): ProsemirrorNode;
+export function convertArrayOfRowsToTableNode(tableNode: ProsemirrorNode, tableArray: Array<Array<ProsemirrorNode | null>>): ProsemirrorNode;
 
 export function canInsert($pos: ResolvedPos, node: ProsemirrorNode | Fragment): boolean;
 


### PR DESCRIPTION
Those functions return an array of array of Prosemirror Node, the type was wrong.