### PR TITLE
Find the common parent in the selection instead of using

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -4,7 +4,7 @@
       "presets":[
         ["env", {
           "targets": {
-            "node": 'current'
+            "node": "current"
           }
         }]
       ]

--- a/.babelrc
+++ b/.babelrc
@@ -2,7 +2,11 @@
   "env": {
     "testing": {
       "presets":[
-        ["env"]
+        ["env", {
+          "targets": {
+            "node": 'current'
+          }
+        }]
       ]
     },
     "production": {

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /node_modules
 /dist
 .vscode
+.idea

--- a/__tests__/selection.js
+++ b/__tests__/selection.js
@@ -56,6 +56,24 @@ describe('selection', () => {
       )(selection);
       expect(result).toBeUndefined();
     });
+    it('should return `undefined` if the whole selection doesnt share the same parent', () => {
+      const {
+        state: { schema, selection }
+      } = createEditor(doc(table(tr(td(p('<start>')))), p('<end>')));
+      const result = findParentNode(node => node.type === schema.nodes.table)(
+        selection
+      );
+      expect(result).toBeUndefined();
+    });
+    it('should return `table` if the whole selection is inside the table', () => {
+      const {
+        state: { schema, selection }
+      } = createEditor(doc(table(tr(td(p('<start>'), td(p('<end>')))))));
+      const { node } = findParentNode(node => node.type === schema.nodes.table)(
+        selection
+      );
+      expect(node.type.name).toEqual('table');
+    });
   });
 
   describe('findParentNodeClosestToPos', () => {

--- a/__tests__/selection.js
+++ b/__tests__/selection.js
@@ -69,10 +69,10 @@ describe('selection', () => {
       const {
         state: { schema, selection }
       } = createEditor(doc(table(tr(td(p('<start>'), td(p('<end>')))))));
-      const { node } = findParentNode(node => node.type === schema.nodes.table)(
-        selection
-      );
-      expect(node.type.name).toEqual('table');
+      const { node } = findParentNode(
+        node => node.type === schema.nodes.table_row
+      )(selection);
+      expect(node.type.name).toEqual('table_row');
     });
   });
 

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "build": "NODE_ENV=production rollup -c",
     "build_readme": "builddocs --name utils --format markdown --main src/README.md src/*.js > README.md",
     "build_all": "npm run build && npm run build_readme",
-    "test": "NODE_ENV=testing jest",
+    "test": "BABEL_ENV=testing jest",
     "test-ci": "NODE_ENV=testing jest --coverage && codecov",
     "prepare": "npm run build_all",
     "precommit": "lint-staged"

--- a/src/selection.js
+++ b/src/selection.js
@@ -8,8 +8,24 @@ import { equalNodeType, isNodeSelection } from './helpers';
 // const predicate = node => node.type === schema.nodes.blockquote;
 // const parent = findParentNode(predicate)(selection);
 // ```
-export const findParentNode = predicate => ({ $from }) =>
-  findParentNodeClosestToPos($from, predicate);
+export const findParentNode = predicate => ({ $from, $to }) => {
+  // Check if parent are different
+  if ($from.parent !== $to.parent) {
+    // If they are, I need to find a common parent
+    let depth = 0;
+    while (depth < $from.depth && depth < $to.depth) {
+      if ($from.node(depth + 1) === $to.node(depth + 1)) {
+        depth = depth + 1;
+        continue;
+      }
+      break;
+    }
+    const pos = depth > 0 ? $from.before(depth) : 0;
+    return findParentNodeClosestToPos($from.doc.resolve(pos), predicate);
+  }
+
+  return findParentNodeClosestToPos($from, predicate);
+};
 
 // :: ($pos: ResolvedPos, predicate: (node: ProseMirrorNode) → boolean) → ?{pos: number, start: number, depth: number, node: ProseMirrorNode}
 // Iterates over parent nodes starting from the given `$pos`, returning the closest node and its start position `predicate` returns truthy for. `start` points to the start position of the node, `pos` points directly before the node.

--- a/src/selection.js
+++ b/src/selection.js
@@ -12,16 +12,26 @@ export const findParentNode = predicate => ({ $from, $to }) => {
   // Check if parent are different
   if ($from.parent !== $to.parent) {
     // If they are, I need to find a common parent
-    let depth = 0;
-    while (depth < $from.depth && depth < $to.depth) {
-      if ($from.node(depth + 1) === $to.node(depth + 1)) {
-        depth = depth + 1;
-        continue;
+    let depth = Math.min($from.depth, $to.depth);
+    while (depth >= 0) {
+      const fromNode = $from.node(depth);
+      const toNode = $to.node(depth);
+      if (toNode === fromNode) {
+        // The have the same parent
+        if (predicate(fromNode)) {
+          // Check the predicate
+          return {
+            // Return the resolved pos
+            pos: depth > 0 ? $from.before(depth) : 0,
+            start: $from.start(depth),
+            depth: depth,
+            node: fromNode
+          };
+        }
       }
-      break;
+      depth = depth - 1; // Keep looking
     }
-    const pos = depth > 0 ? $from.before(depth) : 0;
-    return findParentNodeClosestToPos($from.doc.resolve(pos), predicate);
+    return;
   }
 
   return findParentNodeClosestToPos($from, predicate);

--- a/test-helpers/index.js
+++ b/test-helpers/index.js
@@ -12,12 +12,15 @@ const resolveCell = (doc, tag) => {
 };
 
 const initSelection = doc => {
-  const { cursor, node } = doc.tag;
+  const { cursor, node, start, end } = doc.tag;
   if (node) {
     return new NodeSelection(doc.resolve(node));
   }
   if (typeof cursor === 'number') {
     return new TextSelection(doc.resolve(cursor));
+  }
+  if (typeof start === 'number' && typeof end === 'number') {
+    return new TextSelection(doc.resolve(start), doc.resolve(end));
   }
   const $anchor = resolveCell(doc, doc.tag.anchor);
   if ($anchor) {


### PR DESCRIPTION
Current `findParentNode`implementation doesn't take into consideration if the whole selection is inside the same parent. Causing that some ranges selections has a valid parent in the left side, but is not valid on the right side.

Given this example:
```
doc(
  table(
    tr(
      td(p('cell<start>'))
    )
  ),
  p('paragraph<end>')
)
```
If I try to do `findParentNode((node) => node.type.name === 'table')(selection)` with current implementation will return `tableNode`, but with after this PR it will return `undefined`.