### PR TITLE
Fixed missing property on findSelectedNodeOfType return

### DIFF
--- a/src/selection.js
+++ b/src/selection.js
@@ -121,7 +121,7 @@ export const findSelectedNodeOfType = nodeType => selection => {
   if (isNodeSelection(selection)) {
     const { node, $from } = selection;
     if (equalNodeType(nodeType, node)) {
-      return { node, pos: $from.pos, depth: $from.depth };
+      return { node, pos: $from.pos, depth: $from.depth, start: $from.start() };
     }
   }
 };


### PR DESCRIPTION
This PR adds the missing `start` property to the  `findSelectedNodeOfType` return, which is documented in `typings.d.ts` as `ContentNodeWithPos`; this object is meant to contain a `start` property. The method doc comment also mentions that the return will contain a start property.

An existing issue has also raised this as a bug: https://github.com/atlassian/prosemirror-utils/issues/96 